### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -65,12 +65,22 @@ function getNestedMock(obj: any, path: string): any {
 }
 function setNestedMock(obj: any, path: string, value: any): void {
   const parts = path.split('.');
+  const lastIndex = parts.length - 1;
   let cur = obj;
-  for (let i = 0; i < parts.length - 1; i++) {
-    if (!cur[parts[i]] || typeof cur[parts[i]] !== 'object') cur[parts[i]] = {};
-    cur = cur[parts[i]];
+  for (let i = 0; i < lastIndex; i++) {
+    const key = parts[i];
+    // Prevent prototype pollution via unsafe path segments
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      return;
+    }
+    if (!cur[key] || typeof cur[key] !== 'object') cur[key] = {};
+    cur = cur[key];
   }
-  cur[parts[parts.length - 1]] = value;
+  const lastKey = parts[lastIndex];
+  if (lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') {
+    return;
+  }
+  cur[lastKey] = value;
 }
 function flattenMock(obj: any, prefix = ''): Record<string, string> {
   const result: Record<string, string> = {};


### PR DESCRIPTION
Potential fix for [https://github.com/seabearDEV/codexCLI/security/code-scanning/1](https://github.com/seabearDEV/codexCLI/security/code-scanning/1)

In general, prototype pollution in deep-assignment helpers is prevented by validating each path segment before using it as an object key. The two common strategies are: (1) only traversing into existing own properties on the destination object; or (2) explicitly blocking dangerous keys like `__proto__`, `constructor`, and `prototype` anywhere in the path (often using a small helper such as `lodash`’s `set` which already does this). Here we should minimally adjust `setNestedMock` so it preserves existing behavior (auto-creating intermediate objects), but refuses to operate on dangerous keys.

The best targeted fix is to add a guard inside the `for`-loop in `setNestedMock` that checks each intermediate segment and also checks the final segment before the final assignment. If any segment equals `"__proto__"`, `"constructor"`, or `"prototype"`, the function should bail out early (e.g., `return;`) instead of mutating `cur`. This keeps the function’s current semantics for all normal keys while preventing assignments into `Object.prototype` chains. We do not need new imports or external libraries; a simple inline check suffices. Concretely, within `src/__tests__/mcp-server.test.ts`, we will modify lines 67–73 to introduce a `const last = parts.length - 1;`, validate each `key` in the loop, and validate the last property name before `cur[lastKey] = value;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
