### PR TITLE
Potential fix for code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/src/utils/objectPath.ts
+++ b/src/utils/objectPath.ts
@@ -1,23 +1,36 @@
 import { CodexData, CodexValue } from '../types';
 
+function isSafeKey(key: string): boolean {
+  return key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+}
+
 /**
  * Sets a value at a nested path using dot notation (e.g., 'user.settings.theme')
  */
 export function setNestedValue(obj: CodexData, path: string, value: string): void {
   const keys = path.split('.');
   let current = obj;
-  
+
   // Navigate to the innermost object
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
+    if (!isSafeKey(key)) {
+      // Prevent prototype pollution via special property names
+      return;
+    }
     if (!current[key] || typeof current[key] !== 'object') {
       current[key] = {};
     }
     current = current[key] as CodexData;
   }
-  
+
+  const lastKey = keys[keys.length - 1];
+  if (!isSafeKey(lastKey)) {
+    // Prevent prototype pollution at the final assignment
+    return;
+  }
   // Set the value at the innermost level
-  current[keys[keys.length - 1]] = value;
+  current[lastKey] = value;
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/seabearDEV/codexCLI/security/code-scanning/2](https://github.com/seabearDEV/codexCLI/security/code-scanning/2)

In general, to fix prototype pollution in deep-assignment utilities, you must prevent untrusted input from creating or modifying special prototype-related properties. This is commonly done by rejecting or skipping keys such as `__proto__`, `constructor`, and `prototype`, or by only recursing into properties that are known safe own properties of the destination object.

For this code, the least intrusive and clearest fix is to guard against dangerous key names inside `setNestedValue`. We can introduce a small helper (inside this file) like `isSafeKey(key: string): boolean` that returns `false` for `__proto__`, `constructor`, and `prototype`. Then:

- In the loop that walks/creates intermediate objects (lines 11–17), before reading or writing `current[key]`, check `isSafeKey(key)`; if it’s unsafe, just return early and do nothing.
- Before the final assignment on line 20, check that the last key is safe; if not, return early.

This keeps the existing behavior for all “normal” keys, but ensures that malicious paths like `__proto__.polluted` or `constructor.prototype.polluted` never modify the prototype chain. We do not need any new imports or external dependencies; the helper can be defined at the top of this file. No changes are required for `getNestedValue`, `removeNestedValue`, or `flattenObject` since they don’t create new nested structures or assign to arbitrary objects.

Concretely:
- Add `function isSafeKey(key: string): boolean { ... }` near the top of `src/utils/objectPath.ts`.
- Update `setNestedValue`’s loop body and final write to guard with `isSafeKey`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
