### PR TITLE
Refactor LLM instructions: append model with config command

### DIFF
--- a/.codexcli.json
+++ b/.codexcli.json
@@ -24,7 +24,8 @@
       "cli": "src/index.ts uses Commander.js. Commands: set/get/run/find/edit/copy/rename/remove/init/config/data/stats. Aliases: s/g/r/f/e/cp/rn/rm.",
       "binary": "Production ccli is a Node.js SEA binary. Dev cclid is npm-linked. getBinaryName() detects which via argv.",
       "telemetry": "src/utils/telemetry.ts — JSONL append log at getDataDirectory()/telemetry.jsonl (defaults to ~/.codexcli/telemetry.jsonl in production; overridable via CODEX_DATA_DIR). Logs tool name, session ID, op type (read/write/exec), namespace. computeStats() computes trending metrics. MCP wrapper auto-logs all tool calls.",
-      "interpolation": "src/utils/interpolate.ts — ${key} value refs, $(key) exec refs, ${key:-default} fallbacks, ${key:?error} required checks. Brace-aware parser for nested defaults. Recursive with circular ref detection, max depth 10."
+      "interpolation": "src/utils/interpolate.ts — ${key} value refs, $(key) exec refs, ${key:-default} fallbacks, ${key:?error} required checks. Brace-aware parser for nested defaults. Recursive with circular ref detection, max depth 10.",
+      "llmInstructions": "src/llm-instructions.ts — DEFAULT_LLM_INSTRUCTIONS (immutable built-in), getCustomInstructions() reads system.llm.instructions from store, getEffectiveInstructions() assembles defaults + custom as PROJECT CONTEXT appendix. CLI: ccli config llm-instructions [--default]"
     },
     "conventions": {
       "types": "tsconfig has exactOptionalPropertyTypes: true — optional interface fields need | undefined",

--- a/README.md
+++ b/README.md
@@ -801,17 +801,21 @@ All data-touching tools accept an optional `scope` parameter (`"project"` or `"g
 
 ### LLM Instructions
 
-When an AI agent connects via MCP, CodexCLI automatically sends instructions that guide how the agent interacts with your data store (e.g., defaulting to reads over writes, using depth-limited browsing).
+When an AI agent connects via MCP, CodexCLI sends built-in instructions that guide how the agent interacts with the data store (schema, scope, tool tips, effective usage patterns). These defaults are immutable and stay up to date as features are added.
 
-The default instructions are built into the server. To customize them, set the `system.llm.instructions` key — your version takes priority:
-
-```bash
-ccli set system.llm.instructions "Your custom instructions here"
-```
-
-To revert to the defaults, simply remove the key:
+To add project-specific guidance, set `system.llm.instructions` — your text is **appended** to the defaults as a `PROJECT CONTEXT` section, not a replacement:
 
 ```bash
+# Add project-specific instructions for AI agents
+ccli set system.llm.instructions "This is a monorepo. Always check arch.modules before modifying shared code. Never store secrets, even encrypted."
+
+# View the effective instructions (defaults + your additions)
+ccli config llm-instructions
+
+# View just the built-in defaults
+ccli config llm-instructions --default
+
+# Remove your custom additions (reverts to defaults only)
 ccli rm system.llm.instructions
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,7 @@ CodexCLI is a structured, persistent knowledge base for software projects — ac
 - [x] Shell tab-completion (Bash, Zsh) with dynamic key completion
 - [x] Shell wrapper for `cd`/`export` in current shell
 - [x] Per-entry confirmation (`--confirm` / `--no-confirm`)
-- [x] MCP server with 16 tools for AI agent integration
+- [x] MCP server with 17 tools for AI agent integration
 - [x] LLM instructions (built-in defaults, user-overridable via `system.llm.instructions`)
 - [x] Depth-limited browsing (`--depth` / `-k`)
 - [x] Keys-only default output with `--values` flag
@@ -47,17 +47,48 @@ CodexCLI is a structured, persistent knowledge base for software projects — ac
 - [x] Fixed DEBUG check inconsistency across modules
 - [x] Removed dead code (~100 lines), deduplicated CLI_TREE shortcuts
 
+### v0.9.x (in review)
+- [x] Conditional interpolation: `${key:-default}` and `${key:?error}` ([#14](https://github.com/seabearDEV/codexCLI/issues/14), [PR #31](https://github.com/seabearDEV/codexCLI/pull/31))
+- [x] MCP telemetry: usage tracking, `codex_stats` tool, `ccli stats` command ([PR #32](https://github.com/seabearDEV/codexCLI/pull/32))
+- [x] Configurable backup rotation: `max_backups` config setting ([#10](https://github.com/seabearDEV/codexCLI/issues/10), [PR #33](https://github.com/seabearDEV/codexCLI/pull/33))
+- [x] Init scaffolding: `ccli init --scaffold` for Node.js, Go, Python, Rust ([PR #33](https://github.com/seabearDEV/codexCLI/pull/33))
+- [x] LLM instructions refactor: append model, `ccli config llm-instructions` ([PR #34](https://github.com/seabearDEV/codexCLI/pull/34))
+
 ---
 
-## In Progress / Next Up
+## v1.0.0
+
+The 1.0 milestone represents a stable, feature-complete core — reliable for daily use by both humans and AI agents.
+
+### Stored Command Chains / Macros
+Store reusable sequences of key references that `run` resolves and executes as a chain.
+
+- [ ] Syntax for key references in stored values (e.g., space-separated keys or a dedicated marker) ([#16](https://github.com/seabearDEV/codexCLI/issues/16))
+- [ ] Recursion depth limits and interaction with `--dry`, `--confirm`, interpolation
+
+### Advanced Search
+Make `find` more powerful for large knowledge bases.
+
+- [ ] Regex search patterns (`ccli find --regex "prod.*ip"`) ([#9](https://github.com/seabearDEV/codexCLI/issues/9))
+- [ ] Field-specific search: key-only or value-only filtering
 
 ### Staleness Detection
-Entries go stale as code evolves. The knowledge base needs signals to help agents (and humans) know when to trust stored data.
+Entries go stale as code evolves. Help agents and humans know when to trust stored data.
 
 - [ ] Add optional `_meta` section to data.json tracking last-modified timestamps per key
 - [ ] `codex_context` includes age indicator for old entries (e.g., `[30d]` prefix)
 - [ ] `ccli get --stale <days>` shows entries not updated in N days
 - [ ] MCP tool: `codex_stale` returns entries older than a threshold
+
+### Schema Validation
+Help users and agents follow the recommended schema.
+
+- [ ] `ccli lint` warns about entries outside recognized namespaces
+- [ ] Configurable schema rules in `.codexcli.json` (optional `_schema` section)
+
+---
+
+## Post-1.0
 
 ### Git-Aware Freshness
 Connect stored knowledge to the files it describes. When code changes, flag related entries.
@@ -66,31 +97,9 @@ Connect stored knowledge to the files it describes. When code changes, flag rela
 - [ ] `ccli check` compares entry source files against git diff to flag potentially stale entries
 - [ ] MCP tool: `codex_check` returns entries whose source files have changed since last update
 
-### Schema Validation
-Help users and agents follow the recommended schema.
-
-- [ ] `ccli lint` warns about entries outside recognized namespaces
-- [ ] Configurable schema rules in `.codexcli.json` (optional `_schema` section)
-- [ ] MCP tool descriptions include namespace hints
-
-### Init Scaffolding
-Make project setup faster by auto-populating from existing project files.
-
-- [ ] `ccli init --scaffold` reads `package.json`, `README.md`, `Makefile`, etc. and populates `project.*`, `commands.*`, `deps.*`
-- [ ] Interactive mode: presents discovered info and asks which to keep
-- [ ] Works with non-Node projects (detect Go, Python, Rust, etc.)
-
-### Interpolation Enhancements
-Expand the `${key}` interpolation system with fallbacks and stored command chains.
-
-- [ ] Conditional interpolation: `${ref:-default}` and `${ref:?error}` syntax for fallback values ([#14](https://github.com/seabearDEV/codexCLI/issues/14))
-- [ ] Stored command chains / macros: store a list of key references that `run` resolves and executes as a chain ([#16](https://github.com/seabearDEV/codexCLI/issues/16))
-
-### Search & Navigation
-Make finding and selecting entries faster and more powerful.
-
-- [ ] Advanced search: regex patterns, field-specific search (key-only, value-only), boolean operators ([#9](https://github.com/seabearDEV/codexCLI/issues/9))
-- [ ] Fuzzy finder integration: `ccli get --interactive` or `ccli find --fzf` for interactive key selection ([#13](https://github.com/seabearDEV/codexCLI/issues/13))
+### Search & Navigation Enhancements
+- [ ] Fuzzy finder integration: `ccli get --interactive` or `ccli find --fzf` ([#13](https://github.com/seabearDEV/codexCLI/issues/13))
+- [ ] Boolean search operators (AND, OR, NOT)
 
 ### Richer Data Types
 Currently all values are strings. Some knowledge is better expressed as lists or structured data.
@@ -99,16 +108,11 @@ Currently all values are strings. Some knowledge is better expressed as lists or
 - [ ] Support multi-line values with better display formatting
 - [ ] `codex_get` returns typed JSON when values are structured
 
-### Data Management
-Tools for maintaining the knowledge base over time.
-
-- [ ] Backup rotation: automatic pruning with configurable retention (keep last N backups) ([#10](https://github.com/seabearDEV/codexCLI/issues/10))
-
 ### Team Workflows
 Make the knowledge base useful for teams, not just solo developers.
 
 - [ ] Entry attribution: track who (human or AI) last modified each entry
-- [ ] `ccli log` shows history of changes / audit trail (like `git log` for the knowledge base) ([#12](https://github.com/seabearDEV/codexCLI/issues/12))
+- [ ] `ccli log` shows history of changes / audit trail ([#12](https://github.com/seabearDEV/codexCLI/issues/12))
 - [ ] Merge conflict handling for `.codexcli.json` (custom merge driver or guidance)
 - [ ] `ccli diff` compares local vs committed entries
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -33,6 +33,9 @@ const mockGenerateBashScript = vi.fn().mockReturnValue('bash-script');
 const mockGenerateZshScript = vi.fn().mockReturnValue('zsh-script');
 const mockInstallCompletions = vi.fn();
 
+const mockGetEffectiveInstructions = vi.fn().mockReturnValue('effective instructions');
+const mockDefaultLLMInstructions = 'default instructions';
+
 function setupMocks() {
   vi.doMock('../commands', () => ({
     setEntry: mockSetEntry,
@@ -62,6 +65,10 @@ function setupMocks() {
     generateBashScript: mockGenerateBashScript,
     generateZshScript: mockGenerateZshScript,
     installCompletions: mockInstallCompletions,
+  }));
+  vi.doMock('../llm-instructions', () => ({
+    DEFAULT_LLM_INSTRUCTIONS: mockDefaultLLMInstructions,
+    getEffectiveInstructions: mockGetEffectiveInstructions,
   }));
 }
 
@@ -215,6 +222,17 @@ describe('CLI Entry Point (index.ts)', () => {
   it('config examples calls showExamples', async () => {
     await loadCLI('config', 'examples');
     expect(mockShowExamples).toHaveBeenCalled();
+  });
+
+  it('config llm-instructions prints effective instructions via pager', async () => {
+    await loadCLI('config', 'llm-instructions');
+    expect(mockGetEffectiveInstructions).toHaveBeenCalled();
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('effective instructions'));
+  });
+
+  it('config llm-instructions --default prints built-in defaults via pager', async () => {
+    await loadCLI('config', 'llm-instructions', '--default');
+    expect(process.stdout.write).toHaveBeenCalledWith(expect.stringContaining('default instructions'));
   });
 
   // --- Data subcommands ---

--- a/src/__tests__/llm-instructions.test.ts
+++ b/src/__tests__/llm-instructions.test.ts
@@ -1,0 +1,62 @@
+import { DEFAULT_LLM_INSTRUCTIONS, getCustomInstructions, getEffectiveInstructions } from '../llm-instructions';
+
+vi.mock('../storage', () => ({
+  getValue: vi.fn(),
+}));
+
+import { getValue } from '../storage';
+
+describe('llm-instructions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getCustomInstructions', () => {
+    it('returns undefined when no value is set', () => {
+      vi.mocked(getValue).mockReturnValue(undefined);
+      expect(getCustomInstructions()).toBeUndefined();
+    });
+
+    it('returns the string value when set', () => {
+      vi.mocked(getValue).mockReturnValue('custom instructions');
+      expect(getCustomInstructions()).toBe('custom instructions');
+    });
+
+    it('returns undefined for non-string values', () => {
+      vi.mocked(getValue).mockReturnValue(42);
+      expect(getCustomInstructions()).toBeUndefined();
+    });
+
+    it('returns undefined when getValue throws', () => {
+      vi.mocked(getValue).mockImplementation(() => { throw new Error('storage error'); });
+      expect(getCustomInstructions()).toBeUndefined();
+    });
+  });
+
+  describe('getEffectiveInstructions', () => {
+    it('returns defaults when no custom instructions are set', () => {
+      vi.mocked(getValue).mockReturnValue(undefined);
+      const result = getEffectiveInstructions();
+      expect(result).toBe(DEFAULT_LLM_INSTRUCTIONS);
+    });
+
+    it('appends custom instructions as PROJECT CONTEXT block', () => {
+      vi.mocked(getValue).mockReturnValue('Always check arch.modules first');
+      const result = getEffectiveInstructions();
+      expect(result).toBe(`${DEFAULT_LLM_INSTRUCTIONS}\n\nPROJECT CONTEXT:\nAlways check arch.modules first`);
+    });
+
+    it('returns defaults when custom value is a non-string type', () => {
+      vi.mocked(getValue).mockReturnValue(123);
+      const result = getEffectiveInstructions();
+      expect(result).toBe(DEFAULT_LLM_INSTRUCTIONS);
+    });
+
+    it('includes the separator and header before custom text', () => {
+      vi.mocked(getValue).mockReturnValue('my context');
+      const result = getEffectiveInstructions();
+      expect(result).toContain('\n\nPROJECT CONTEXT:\n');
+      expect(result).toContain('my context');
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { withPager } from './utils/pager';
 import { getDataDirectory } from './utils/paths';
 import { getBinaryName } from './utils/binaryName';
 import fs from 'fs';
+import { DEFAULT_LLM_INSTRUCTIONS, getEffectiveInstructions } from './llm-instructions';
 
 // Early-exit handler for shell tab-completion (must run before Commander parses args)
 const completionFlagIndex = process.argv.indexOf('--get-completions');
@@ -284,9 +285,8 @@ configCommand
   .description('Show the LLM instructions sent to AI agents via MCP')
   .option('--default', 'Show only the built-in defaults (exclude custom additions)')
   .action(async (options: { default?: boolean }) => {
-    const { DEFAULT_LLM_INSTRUCTIONS, getEffectiveInstructions } = await import('./llm-instructions');
     const text = options.default ? DEFAULT_LLM_INSTRUCTIONS : getEffectiveInstructions();
-    console.log(text);
+    await withPager(() => { process.stdout.write(text + '\n'); });
   });
 
 const completionsCommand = configCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,6 +279,16 @@ configCommand
   .description('Show usage examples')
   .action(() => { void withPager(() => showExamples()); });
 
+configCommand
+  .command('llm-instructions')
+  .description('Show the LLM instructions sent to AI agents via MCP')
+  .option('--default', 'Show only the built-in defaults (exclude custom additions)')
+  .action(async (options: { default?: boolean }) => {
+    const { DEFAULT_LLM_INSTRUCTIONS, getEffectiveInstructions } = await import('./llm-instructions');
+    const text = options.default ? DEFAULT_LLM_INSTRUCTIONS : getEffectiveInstructions();
+    console.log(text);
+  });
+
 const completionsCommand = configCommand
   .command('completions')
   .description('Generate shell completion scripts')

--- a/src/llm-instructions.ts
+++ b/src/llm-instructions.ts
@@ -1,0 +1,60 @@
+import { getValue } from './storage';
+
+export const DEFAULT_LLM_INSTRUCTIONS = `You are connected to a CodexCLI data store via MCP. This store is a persistent, structured knowledge base for the project you are working on. Use it to learn, record, and share context across sessions and AI agents.
+
+HOW TO USE:
+- At session start, call codex_context to load all stored project knowledge in one call.
+- Before exploring the codebase (reading files, searching code), check if the answer is already stored — e.g. codex_get with key "arch" or "conventions" or "commands".
+- When you discover something non-obvious about the project (architecture decisions, gotchas, patterns, key file roles), store it with codex_set.
+- When you find stored information that is outdated or wrong, update it immediately.
+- Do NOT store things easily derived from package.json, README, or the code itself. Store insights, decisions, and context that would otherwise be lost between sessions.
+
+SCHEMA (recommended namespaces):
+- project.*      — name, description, stack, repo URL
+- commands.*     — build, test, lint, deploy commands
+- arch.*         — architecture notes, patterns, key decisions
+- conventions.*  — coding patterns, naming rules, style notes
+- context.*      — non-obvious gotchas, edge cases, historical decisions
+- files.*        — key file paths and their roles
+- deps.*         — notable dependencies and why they are used
+
+SCOPE:
+- If a .codexcli.json project file exists, reads/writes default to the project scope.
+- Use scope: "global" to target the user's personal global store (~/.codexcli/data.json).
+- codex_get with no key shows project entries by default. Pass all: true to see both scopes.
+
+TOOL TIPS:
+- codex_context — compact summary of all entries (best for session start)
+- codex_get — retrieve specific keys or browse namespaces (use depth: 1 to scan top-level)
+- codex_set — store a key-value pair (use dot notation, keep values concise)
+- codex_search — find entries by keyword
+- codex_run — execute a stored shell command (respects confirm metadata)
+- codex_stats — view your usage metrics (bootstrap rate, write-back rate, trends)
+
+EFFECTIVE USAGE:
+- Always call codex_context as your FIRST tool call to bootstrap session knowledge.
+- Write back: when you learn something non-obvious, store it before the session ends.
+- Usage is tracked — codex_stats shows how effectively the knowledge base is being used.`;
+
+/**
+ * Get the custom LLM instructions from the data store, if any.
+ * Returns undefined if not set.
+ */
+export function getCustomInstructions(): string | undefined {
+  try {
+    const val = getValue('system.llm.instructions');
+    return typeof val === 'string' ? val : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Assemble the effective LLM instructions: built-in defaults + optional custom section.
+ * Custom instructions are appended as a PROJECT CONTEXT block, not a replacement.
+ */
+export function getEffectiveInstructions(): string {
+  const custom = getCustomInstructions();
+  if (!custom) return DEFAULT_LLM_INSTRUCTIONS;
+  return `${DEFAULT_LLM_INSTRUCTIONS}\n\nPROJECT CONTEXT:\n${custom}`;
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,6 +34,7 @@ import { formatTree, resetColorCache } from "./formatting";
 import { isEncrypted, maskEncryptedValues, encryptValue, decryptValue } from "./utils/crypto";
 import { interpolate, interpolateObject } from "./utils/interpolate";
 import { logToolCall, computeStats } from "./utils/telemetry";
+import { getEffectiveInstructions } from "./llm-instructions";
 
 function toScope(scopeParam?: string): Scope {
   return (scopeParam ?? 'auto') as Scope;
@@ -48,48 +49,11 @@ function errorResponse(text: string) {
 
 ensureDataDirectoryExists();
 
-const DEFAULT_LLM_INSTRUCTIONS = `You are connected to a CodexCLI data store via MCP. This store is a persistent, structured knowledge base for the project you are working on. Use it to learn, record, and share context across sessions and AI agents.
-
-HOW TO USE:
-- At session start, call codex_context to load all stored project knowledge in one call.
-- Before exploring the codebase (reading files, searching code), check if the answer is already stored — e.g. codex_get with key "arch" or "conventions" or "commands".
-- When you discover something non-obvious about the project (architecture decisions, gotchas, patterns, key file roles), store it with codex_set.
-- When you find stored information that is outdated or wrong, update it immediately.
-- Do NOT store things easily derived from package.json, README, or the code itself. Store insights, decisions, and context that would otherwise be lost between sessions.
-
-SCHEMA (recommended namespaces):
-- project.*      — name, description, stack, repo URL
-- commands.*     — build, test, lint, deploy commands
-- arch.*         — architecture notes, patterns, key decisions
-- conventions.*  — coding patterns, naming rules, style notes
-- context.*      — non-obvious gotchas, edge cases, historical decisions
-- files.*        — key file paths and their roles
-- deps.*         — notable dependencies and why they are used
-
-SCOPE:
-- If a .codexcli.json project file exists, reads/writes default to the project scope.
-- Use scope: "global" to target the user's personal global store (~/.codexcli/data.json).
-- codex_get with no key shows project entries by default. Pass all: true to see both scopes.
-
-TOOL TIPS:
-- codex_context — compact summary of all entries (best for session start)
-- codex_get — retrieve specific keys or browse namespaces (use depth: 1 to scan top-level)
-- codex_set — store a key-value pair (use dot notation, keep values concise)
-- codex_search — find entries by keyword
-- codex_run — execute a stored shell command (respects confirm metadata)
-- codex_stats — view your usage metrics (bootstrap rate, write-back rate, trends)
-
-EFFECTIVE USAGE:
-- Always call codex_context as your FIRST tool call to bootstrap session knowledge.
-- Write back: when you learn something non-obvious, store it before the session ends.
-- Usage is tracked — codex_stats shows how effectively the knowledge base is being used.`;
-
 const llmInstructions = (() => {
   try {
     loadData();
-    const val = getValue('system.llm.instructions');
-    return typeof val === 'string' ? val : DEFAULT_LLM_INSTRUCTIONS;
-  } catch { return DEFAULT_LLM_INSTRUCTIONS; }
+    return getEffectiveInstructions();
+  } catch { return getEffectiveInstructions(); }
 })();
 
 const server = new McpServer(

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -49,12 +49,7 @@ function errorResponse(text: string) {
 
 ensureDataDirectoryExists();
 
-const llmInstructions = (() => {
-  try {
-    loadData();
-    return getEffectiveInstructions();
-  } catch { return getEffectiveInstructions(); }
-})();
+const llmInstructions = getEffectiveInstructions();
 
 const server = new McpServer(
   { name: "codexcli", version },


### PR DESCRIPTION
## Summary
- **Breaking change**: `system.llm.instructions` now **appends** to built-in defaults as a `PROJECT CONTEXT` section instead of replacing them entirely
- **New command**: `ccli config llm-instructions` shows effective instructions, `--default` shows just built-ins
- Extracted `src/llm-instructions.ts` shared module (MCP server + CLI both use it)

### Before
```bash
ccli set system.llm.instructions "custom"
# Agent sees ONLY "custom" — loses schema docs, tool tips, scope explanation
```

### After
```bash
ccli set system.llm.instructions "Always check arch.modules first"
# Agent sees full defaults + "PROJECT CONTEXT: Always check arch.modules first"
```

## Test plan
- [x] All 501 tests passing
- [x] `ccli config llm-instructions` shows defaults when no custom set
- [x] `ccli config llm-instructions` appends custom as PROJECT CONTEXT when set
- [x] `ccli config llm-instructions --default` always shows just built-ins
- [x] Removing `system.llm.instructions` reverts to defaults-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)