### PR TITLE
v1.0 features: command chains, regex search, staleness detection, schema lint

### DIFF
--- a/.codexcli.json
+++ b/.codexcli.json
@@ -1,63 +1,12 @@
 {
   "_meta": {
-    "search.test.1": 1775343265410,
-    "search.test.2": 1775343265515,
-    "test.key": 1775343265235
+    "search.test.1": 1775344229508,
+    "search.test.2": 1775344229604,
+    "test.key": 1775344229327
   },
   "aliases": {},
   "confirm": {},
   "entries": {
-    "project": {
-      "name": "CodexCLI",
-      "description": "CLI tool and MCP server for storing, organizing, and retrieving structured data with dot notation",
-      "stack": "TypeScript, Node.js, Commander.js, Vitest, MCP SDK (@modelcontextprotocol/sdk)"
-    },
-    "commands": {
-      "build": "npm run build",
-      "test": "npm test",
-      "lint": "npm run lint",
-      "dev": "npm run dev:watch",
-      "test.watch": "npm run test:watch",
-      "release": "git tag v<version> && git push origin v<version> — triggers .github/workflows/release.yml which builds SEA binaries and updates Homebrew tap"
-    },
-    "arch": {
-      "storage": "Unified data.json with { entries, aliases, confirm } sections. Global at ~/.codexcli/data.json, project at .codexcli.json",
-      "store": "src/store.ts is the core — ScopedStore with mtime caching, auto-migration from old 3-file format, project file detection via directory walk-up",
-      "scope": "Scope type: 'project' | 'global' | 'auto'. Auto uses project if .codexcli.json exists, else global. Single-key lookups fall through project -> global. Listings show one scope at a time.",
-      "scaffold": "ccli init --scaffold reads package.json, go.mod, pyproject.toml, Cargo.toml to auto-populate project.*, commands.* namespaces. Idempotent — skips existing entries. Logic in src/commands/data-management.ts scaffoldProject().",
-      "mcp": "src/mcp-server.ts exposes 17 tools via MCP SDK (codex_stats added in this PR). All data tools accept optional scope parameter. codex_context is the session bootstrap tool.",
-      "cli": "src/index.ts uses Commander.js. Commands: set/get/run/find/edit/copy/rename/remove/init/config/data/stats. Aliases: s/g/r/f/e/cp/rn/rm.",
-      "binary": "Production ccli is a Node.js SEA binary. Dev cclid is npm-linked. getBinaryName() detects which via argv.",
-      "telemetry": "src/utils/telemetry.ts — JSONL append log at getDataDirectory()/telemetry.jsonl (defaults to ~/.codexcli/telemetry.jsonl in production; overridable via CODEX_DATA_DIR). Logs tool name, session ID, op type (read/write/exec), namespace. computeStats() computes trending metrics. MCP wrapper auto-logs all tool calls.",
-      "interpolation": "src/utils/interpolate.ts — ${key} value refs, $(key) exec refs, ${key:-default} fallbacks, ${key:?error} required checks. Brace-aware parser for nested defaults. Recursive with circular ref detection, max depth 10.",
-      "staleness": "_meta section in data.json tracks last-modified timestamp per key. touchMeta/removeMeta in store.ts, auto-called by setValue/removeValue. ccli stale [days], codex_stale MCP tool, codex_context shows [Nd] age tags for entries >30d old.",
-      "lint": "src/commands/lint.ts — ccli lint checks entries against recommended namespace schema (project/commands/arch/conventions/context/files/deps/system). Custom namespaces via _schema.namespaces in .codexcli.json."
-      "llmInstructions": "src/llm-instructions.ts — DEFAULT_LLM_INSTRUCTIONS (immutable built-in), getCustomInstructions() reads system.llm.instructions from store, getEffectiveInstructions() assembles defaults + custom as PROJECT CONTEXT appendix. CLI: ccli config llm-instructions [--default]"
-    },
-    "conventions": {
-      "types": "tsconfig has exactOptionalPropertyTypes: true — optional interface fields need | undefined",
-      "output": "All user-facing text uses getBinaryName() from src/utils/binaryName.ts — never hardcode ccli",
-      "tests": "Vitest with globals. Unit tests mock fs and store module. Integration tests use real temp dirs via CODEX_DATA_DIR env var.",
-      "atomicWrites": "All file writes use saveJsonSorted -> withFileLock -> atomicWriteFileSync (tmp file + rename)",
-      "debug": "Always use process.env.DEBUG === 'true' (strict equality). CLI --debug flag sets it to 'true'. Never use truthy check."
-    },
-    "context": {
-      "migration": "On first access, auto-migrates old separate files (entries.json + aliases.json + confirm.json) to unified data.json. Old files renamed to .backup.",
-      "configSeparate": "config.json stays separate from data.json — it is user preference not project data",
-      "mcpCwd": "MCP server needs --cwd or CODEX_PROJECT_DIR to detect project files since its process.cwd() may not be the project root",
-      "testDataLeaks": "CODEX_DATA_DIR only redirects the global store path. If a .codexcli.json exists in cwd, writes still hit the project store. Use a temp working directory or git checkout to clean up after live CLI testing."
-    },
-    "files": {
-      "entry": "src/index.ts (CLI entry), src/mcp-server.ts (MCP entry)",
-      "store": "src/store.ts (unified store, caching, migration, scope resolution)",
-      "storage": "src/storage.ts (thin wrapper — loadData, getValue, setValue delegate to store)",
-      "alias": "src/alias.ts (alias CRUD — resolveKey, setAlias, removeAliasesForKey)",
-      "confirm": "src/confirm.ts (confirm flag CRUD — hasConfirm, setConfirm)",
-      "commands": "src/commands/entries.ts (set/get/run/remove/copy/edit/rename handlers)",
-      "completions": "src/completions.ts (CLI_TREE defines all commands, getDynamicValues for tab completion)",
-      "formatting": "src/formatting.ts (showHelp, showExamples, displayTree, color utilities)",
-      "interpolate": "src/utils/interpolate.ts (${key} value interpolation, $(key) exec interpolation, conditional modifiers)"
-    },
     "test": {
       "key": "test value"
     },
@@ -65,23 +14,6 @@
       "test": {
         "1": "searchable value one",
         "2": "searchable value two"
-      }
-    },
-    "cmd": {
-      "a": "echo step-a",
-      "b": "echo step-b",
-      "c": "echo step-c"
-    },
-    "macros": {
-      "all": "cmd.a cmd.b cmd.c"
-    },
-    "server": {
-      "prod": {
-        "ip": "10.0.0.1",
-        "port": "8080"
-      },
-      "dev": {
-        "ip": "127.0.0.1"
       }
     }
   }

--- a/.codexcli.json
+++ b/.codexcli.json
@@ -1,4 +1,9 @@
 {
+  "_meta": {
+    "search.test.1": 1775343265410,
+    "search.test.2": 1775343265515,
+    "test.key": 1775343265235
+  },
   "aliases": {},
   "confirm": {},
   "entries": {

--- a/.codexcli.json
+++ b/.codexcli.json
@@ -24,7 +24,9 @@
       "cli": "src/index.ts uses Commander.js. Commands: set/get/run/find/edit/copy/rename/remove/init/config/data/stats. Aliases: s/g/r/f/e/cp/rn/rm.",
       "binary": "Production ccli is a Node.js SEA binary. Dev cclid is npm-linked. getBinaryName() detects which via argv.",
       "telemetry": "src/utils/telemetry.ts — JSONL append log at getDataDirectory()/telemetry.jsonl (defaults to ~/.codexcli/telemetry.jsonl in production; overridable via CODEX_DATA_DIR). Logs tool name, session ID, op type (read/write/exec), namespace. computeStats() computes trending metrics. MCP wrapper auto-logs all tool calls.",
-      "interpolation": "src/utils/interpolate.ts — ${key} value refs, $(key) exec refs, ${key:-default} fallbacks, ${key:?error} required checks. Brace-aware parser for nested defaults. Recursive with circular ref detection, max depth 10."
+      "interpolation": "src/utils/interpolate.ts — ${key} value refs, $(key) exec refs, ${key:-default} fallbacks, ${key:?error} required checks. Brace-aware parser for nested defaults. Recursive with circular ref detection, max depth 10.",
+      "staleness": "_meta section in data.json tracks last-modified timestamp per key. touchMeta/removeMeta in store.ts, auto-called by setValue/removeValue. ccli stale [days], codex_stale MCP tool, codex_context shows [Nd] age tags for entries >30d old.",
+      "lint": "src/commands/lint.ts — ccli lint checks entries against recommended namespace schema (project/commands/arch/conventions/context/files/deps/system). Custom namespaces via _schema.namespaces in .codexcli.json."
     },
     "conventions": {
       "types": "tsconfig has exactOptionalPropertyTypes: true — optional interface fields need | undefined",
@@ -57,6 +59,23 @@
       "test": {
         "1": "searchable value one",
         "2": "searchable value two"
+      }
+    },
+    "cmd": {
+      "a": "echo step-a",
+      "b": "echo step-b",
+      "c": "echo step-c"
+    },
+    "macros": {
+      "all": "cmd.a cmd.b cmd.c"
+    },
+    "server": {
+      "prod": {
+        "ip": "10.0.0.1",
+        "port": "8080"
+      },
+      "dev": {
+        "ip": "127.0.0.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 			},
 			"devDependencies": {
 				"@types/node": "^22.13.8",
+				"@vitest/coverage-v8": "^4.1.2",
 				"esbuild": "^0.25.0",
 				"eslint": "^10.0.1",
 				"postject": "^1.0.0-alpha.6",
@@ -27,6 +28,103 @@
 				"typescript": "^5.8.2",
 				"typescript-eslint": "^8.56.0",
 				"vitest": "^4.0.18"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+			"integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -642,12 +740,33 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.26.0",
@@ -689,24 +808,39 @@
 				}
 			}
 		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
-			"integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
-			"cpu": [
-				"arm"
-			],
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+			"integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"os": [
-				"android"
-			]
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
 		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
-			"integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+		"node_modules/@oxc-project/types": {
+			"version": "0.122.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+			"integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+			"integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
 			"cpu": [
 				"arm64"
 			],
@@ -715,12 +849,15 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
-			"integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+			"integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
 			"cpu": [
 				"arm64"
 			],
@@ -729,12 +866,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
-			"integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+			"integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
 			"cpu": [
 				"x64"
 			],
@@ -743,26 +883,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
-			"integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
-			"cpu": [
-				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
-			"integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+			"integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
 			"cpu": [
 				"x64"
 			],
@@ -771,12 +900,15 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
-			"integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+			"integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
 			"cpu": [
 				"arm"
 			],
@@ -785,26 +917,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
-			"integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
-			"cpu": [
-				"arm"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
-			"integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+			"integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
 			"cpu": [
 				"arm64"
 			],
@@ -813,12 +934,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
-			"integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+			"integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
 			"cpu": [
 				"arm64"
 			],
@@ -827,40 +951,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
-			"integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
-			"cpu": [
-				"loong64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
-			"integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
-			"integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+			"integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -869,54 +968,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
-			"integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
-			"cpu": [
-				"ppc64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
-			"integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
-			"integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
-			"integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+			"integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
 			"cpu": [
 				"s390x"
 			],
@@ -925,12 +985,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+			"integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
 			"cpu": [
 				"x64"
 			],
@@ -939,12 +1002,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
-			"integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+			"integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
 			"cpu": [
 				"x64"
 			],
@@ -953,26 +1019,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
-			"integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
-			"cpu": [
-				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
-			"integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+			"integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
 			"cpu": [
 				"arm64"
 			],
@@ -981,12 +1036,32 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
-			"integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+			"integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+			"integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -995,26 +1070,15 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
-			"integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
-			"cpu": [
-				"ia32"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
-			"integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+			"integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
 			"cpu": [
 				"x64"
 			],
@@ -1023,21 +1087,17 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
-			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
-			"cpu": [
-				"x64"
 			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+			"integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"license": "MIT"
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -1045,6 +1105,17 @@
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
@@ -1325,72 +1396,76 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@vitest/expect": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+		"node_modules/@vitest/coverage-v8": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+			"integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@standard-schema/spec": "^1.0.0",
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"chai": "^6.2.1",
-				"tinyrainbow": "^3.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/mocker": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.0.18",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
+				"@bcoe/v8-coverage": "^1.0.2",
+				"@vitest/utils": "4.1.2",
+				"ast-v8-to-istanbul": "^1.0.0",
+				"istanbul-lib-coverage": "^3.2.2",
+				"istanbul-lib-report": "^3.0.1",
+				"istanbul-reports": "^3.2.0",
+				"magicast": "^0.5.2",
+				"obug": "^2.1.1",
+				"std-env": "^4.0.0-rc.1",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
+				"@vitest/browser": "4.1.2",
+				"vitest": "4.1.2"
 			},
 			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
+				"@vitest/browser": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+		"node_modules/@vitest/expect": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+			"integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^3.0.3"
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.2",
+				"@vitest/utils": "4.1.2",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+			"integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+			"integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.18",
+				"@vitest/utils": "4.1.2",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -1398,13 +1473,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+			"integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
+				"@vitest/pretty-format": "4.1.2",
+				"@vitest/utils": "4.1.2",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -1413,9 +1489,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+			"integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -1423,14 +1499,15 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+			"integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
-				"tinyrainbow": "^3.0.3"
+				"@vitest/pretty-format": "4.1.2",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
@@ -1528,6 +1605,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ast-v8-to-istanbul": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.31",
+				"estree-walker": "^3.0.3",
+				"js-tokens": "^10.0.0"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -1690,6 +1779,13 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1772,6 +1868,16 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1820,9 +1926,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2458,6 +2564,13 @@
 				"node": ">=16.9.0"
 			}
 		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2573,6 +2686,45 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"license": "ISC"
 		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/jose": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -2581,6 +2733,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
+		},
+		"node_modules/js-tokens": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -2632,6 +2791,267 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2656,6 +3076,34 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/magicast": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+			"integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -2948,9 +3396,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3083,49 +3531,38 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rollup": {
-			"version": "4.59.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
-			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+		"node_modules/rolldown": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+			"integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.8"
+				"@oxc-project/types": "=0.122.0",
+				"@rolldown/pluginutils": "1.0.0-rc.12"
 			},
 			"bin": {
-				"rollup": "dist/bin/rollup"
+				"rolldown": "bin/cli.mjs"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.59.0",
-				"@rollup/rollup-android-arm64": "4.59.0",
-				"@rollup/rollup-darwin-arm64": "4.59.0",
-				"@rollup/rollup-darwin-x64": "4.59.0",
-				"@rollup/rollup-freebsd-arm64": "4.59.0",
-				"@rollup/rollup-freebsd-x64": "4.59.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.59.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.59.0",
-				"@rollup/rollup-linux-arm64-musl": "4.59.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.59.0",
-				"@rollup/rollup-linux-loong64-musl": "4.59.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.59.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.59.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.59.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.59.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-gnu": "4.59.0",
-				"@rollup/rollup-linux-x64-musl": "4.59.0",
-				"@rollup/rollup-openbsd-x64": "4.59.0",
-				"@rollup/rollup-openharmony-arm64": "4.59.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.59.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.59.0",
-				"@rollup/rollup-win32-x64-gnu": "4.59.0",
-				"@rollup/rollup-win32-x64-msvc": "4.59.0",
-				"fsevents": "~2.3.2"
+				"@rolldown/binding-android-arm64": "1.0.0-rc.12",
+				"@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+				"@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+				"@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+				"@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+				"@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+				"@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
 			}
 		},
 		"node_modules/router": {
@@ -3341,9 +3778,9 @@
 			}
 		},
 		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+			"integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3394,9 +3831,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3532,591 +3969,32 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
-			},
-			"bin": {
-				"vite": "bin/vite.js"
-			},
-			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
-			},
-			"funding": {
-				"url": "https://github.com/vitejs/vite?sponsor=1"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.3"
-			},
-			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
-				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
-				"terser": "^5.16.0",
-				"tsx": "^4.8.1",
-				"yaml": "^2.4.2"
-			},
-			"peerDependenciesMeta": {
-				"@types/node": {
-					"optional": true
-				},
-				"jiti": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"lightningcss": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"sass-embedded": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"terser": {
-					"optional": true
-				},
-				"tsx": {
-					"optional": true
-				},
-				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
-			}
-		},
 		"node_modules/vitest": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+			"integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.0.18",
-				"@vitest/mocker": "4.0.18",
-				"@vitest/pretty-format": "4.0.18",
-				"@vitest/runner": "4.0.18",
-				"@vitest/snapshot": "4.0.18",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"es-module-lexer": "^1.7.0",
-				"expect-type": "^1.2.2",
+				"@vitest/expect": "4.1.2",
+				"@vitest/mocker": "4.1.2",
+				"@vitest/pretty-format": "4.1.2",
+				"@vitest/runner": "4.1.2",
+				"@vitest/snapshot": "4.1.2",
+				"@vitest/spy": "4.1.2",
+				"@vitest/utils": "4.1.2",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
 				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
 				"picomatch": "^4.0.3",
-				"std-env": "^3.10.0",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.0.3",
-				"vite": "^6.0.0 || ^7.0.0",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -4132,12 +4010,13 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.18",
-				"@vitest/browser-preview": "4.0.18",
-				"@vitest/browser-webdriverio": "4.0.18",
-				"@vitest/ui": "4.0.18",
+				"@vitest/browser-playwright": "4.1.2",
+				"@vitest/browser-preview": "4.1.2",
+				"@vitest/browser-webdriverio": "4.1.2",
+				"@vitest/ui": "4.1.2",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -4165,6 +4044,626 @@
 					"optional": true
 				},
 				"jsdom": {
+					"optional": true
+				},
+				"vite": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+			"integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+			"integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+			"integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+			"integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+			"integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+			"integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+			"integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+			"integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+			"integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+			"integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+			"integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+			"integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+			"integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+			"integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+			"integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+			"integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+			"integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+			"integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+			"integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+			"integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+			"integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+			"integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+			"integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@vitest/mocker": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+			"integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.2",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vitest/node_modules/esbuild": {
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.7",
+				"@esbuild/android-arm": "0.27.7",
+				"@esbuild/android-arm64": "0.27.7",
+				"@esbuild/android-x64": "0.27.7",
+				"@esbuild/darwin-arm64": "0.27.7",
+				"@esbuild/darwin-x64": "0.27.7",
+				"@esbuild/freebsd-arm64": "0.27.7",
+				"@esbuild/freebsd-x64": "0.27.7",
+				"@esbuild/linux-arm": "0.27.7",
+				"@esbuild/linux-arm64": "0.27.7",
+				"@esbuild/linux-ia32": "0.27.7",
+				"@esbuild/linux-loong64": "0.27.7",
+				"@esbuild/linux-mips64el": "0.27.7",
+				"@esbuild/linux-ppc64": "0.27.7",
+				"@esbuild/linux-riscv64": "0.27.7",
+				"@esbuild/linux-s390x": "0.27.7",
+				"@esbuild/linux-x64": "0.27.7",
+				"@esbuild/netbsd-arm64": "0.27.7",
+				"@esbuild/netbsd-x64": "0.27.7",
+				"@esbuild/openbsd-arm64": "0.27.7",
+				"@esbuild/openbsd-x64": "0.27.7",
+				"@esbuild/openharmony-arm64": "0.27.7",
+				"@esbuild/sunos-x64": "0.27.7",
+				"@esbuild/win32-arm64": "0.27.7",
+				"@esbuild/win32-ia32": "0.27.7",
+				"@esbuild/win32-x64": "0.27.7"
+			}
+		},
+		"node_modules/vitest/node_modules/vite": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+			"integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.8",
+				"rolldown": "1.0.0-rc.12",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.0",
+				"esbuild": "^0.27.0",
+				"jiti": ">=1.21.0",
+				"less": "^4.0.0",
+				"sass": "^1.70.0",
+				"sass-embedded": "^1.70.0",
+				"stylus": ">=0.54.8",
+				"sugarss": "^5.0.0",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.13.8",
+		"@vitest/coverage-v8": "^4.1.2",
 		"esbuild": "^0.25.0",
 		"eslint": "^10.0.1",
 		"postject": "^1.0.0-alpha.6",

--- a/src/__tests__/autoBackup.test.ts
+++ b/src/__tests__/autoBackup.test.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { createAutoBackup } from '../utils/autoBackup';
+
+let tmpDir: string;
+
+vi.mock('../utils/paths', () => ({
+  getDataDirectory: () => tmpDir,
+}));
+
+vi.mock('../config', () => ({
+  getConfigSetting: vi.fn((key: string) => {
+    if (key === 'max_backups') return 3;
+    return null;
+  }),
+}));
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-backup-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('createAutoBackup', () => {
+  it('creates a backup directory with data.json copy', () => {
+    fs.writeFileSync(path.join(tmpDir, 'data.json'), '{"entries":{}}');
+
+    const result = createAutoBackup('test');
+
+    expect(result).toBeTruthy();
+    expect(fs.existsSync(result!)).toBe(true);
+    expect(fs.existsSync(path.join(result!, 'data.json'))).toBe(true);
+  });
+
+  it('returns null when no files to back up', () => {
+    // No data files in tmpDir
+    const result = createAutoBackup('test');
+    expect(result).toBeNull();
+  });
+
+  it('rotates old backups based on max_backups config', () => {
+    fs.writeFileSync(path.join(tmpDir, 'data.json'), '{}');
+    const backupDir = path.join(tmpDir, '.backups');
+
+    // Create 5 existing backups
+    fs.mkdirSync(backupDir, { recursive: true });
+    for (let i = 0; i < 5; i++) {
+      const dir = path.join(backupDir, `old-${String(i).padStart(3, '0')}`);
+      fs.mkdirSync(dir);
+      // Give them staggered mtimes
+      const time = new Date(2020, 0, 1 + i);
+      fs.utimesSync(dir, time, time);
+    }
+
+    // Create a new backup (max_backups = 3)
+    createAutoBackup('new');
+
+    const remaining = fs.readdirSync(backupDir);
+    // Should keep 3 total (pruned the oldest)
+    expect(remaining.length).toBe(3);
+  });
+
+  it('backs up legacy files when they exist', () => {
+    fs.writeFileSync(path.join(tmpDir, 'entries.json'), '{}');
+    fs.writeFileSync(path.join(tmpDir, 'aliases.json'), '{}');
+
+    const result = createAutoBackup('legacy');
+
+    expect(result).toBeTruthy();
+    expect(fs.existsSync(path.join(result!, 'entries.json'))).toBe(true);
+    expect(fs.existsSync(path.join(result!, 'aliases.json'))).toBe(true);
+  });
+
+  it('labels backup directory with the provided label', () => {
+    fs.writeFileSync(path.join(tmpDir, 'data.json'), '{}');
+
+    const result = createAutoBackup('pre-import');
+
+    expect(result).toBeTruthy();
+    expect(path.basename(result!)).toMatch(/^pre-import-/);
+  });
+});

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -78,6 +78,10 @@ vi.mock('../store', () => {
     findProjectFile:    vi.fn(() => null),
     clearProjectFileCache: vi.fn(),
     getEffectiveScope:  vi.fn(() => 'global'),
+    touchMeta:          vi.fn(),
+    removeMeta:         vi.fn(),
+    loadMeta:           vi.fn(() => ({})),
+    loadMetaMerged:     vi.fn(() => ({})),
   };
 });
 
@@ -641,6 +645,51 @@ describe('Commands', () => {
       await runCommand(['commands.cd:paths.project', 'commands.list'], { yes: true });
 
       expect(execSync).toHaveBeenCalledWith('cd /Users/me/project && ls -l', { stdio: 'inherit', shell: process.env.SHELL || '/bin/sh' });
+    });
+  });
+
+  describe('runCommand --chain', () => {
+    it('resolves space-separated keys and chains with &&', async () => {
+      storeState.entries = {
+        cmd: { a: 'echo step-a', b: 'echo step-b' },
+        macros: { both: 'cmd.a cmd.b' },
+      };
+
+      await runCommand(['macros.both'], { yes: true, chain: true });
+
+      expect(execSync).toHaveBeenCalledWith('echo step-a && echo step-b', { stdio: 'inherit', shell: process.env.SHELL || '/bin/sh' });
+    });
+
+    it('supports dry run with --chain', async () => {
+      storeState.entries = {
+        cmd: { a: 'echo step-a', b: 'echo step-b' },
+        macros: { both: 'cmd.a cmd.b' },
+      };
+
+      await runCommand(['macros.both'], { dry: true, chain: true });
+
+      expect(execSync).not.toHaveBeenCalled();
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('echo step-a && echo step-b'));
+    });
+
+    it('errors when a chain key is not found', async () => {
+      storeState.entries = {
+        macros: { bad: 'cmd.exists cmd.missing' },
+        cmd: { exists: 'echo ok' },
+      };
+
+      await runCommand(['macros.bad'], { yes: true, chain: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(execSync).not.toHaveBeenCalled();
+    });
+
+    it('errors when chain entry itself is not found', async () => {
+      storeState.entries = {};
+
+      await runCommand(['macros.nope'], { yes: true, chain: true });
+
+      expect(process.exitCode).toBe(1);
     });
   });
 

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -1291,6 +1291,55 @@ describe('Commands', () => {
     });
   });
 
+  describe('searchEntries regex and field filters', () => {
+    it('matches entries by regex pattern', () => {
+      storeState.entries = {
+        server: { prod: { ip: '10.0.0.1' }, dev: { ip: '127.0.0.1' } },
+      };
+
+      searchEntries('prod.*ip', { regex: true });
+
+      const output = (console.log as Mock).mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(output).toContain('server.prod.ip');
+      expect(output).not.toContain('server.dev.ip');
+    });
+
+    it('shows error for invalid regex', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      searchEntries('[invalid', { regex: true });
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('filters by keys only', () => {
+      storeState.entries = { server: { ip: '10.0.0.1' } };
+
+      searchEntries('10.0', { keys: true });
+
+      // "10.0" is only in the value, not the key
+      const output = (console.log as Mock).mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(output).toContain('No matches');
+    });
+
+    it('filters by values only', () => {
+      storeState.entries = { server: { ip: '10.0.0.1' } };
+
+      searchEntries('server', { values: true });
+
+      // "server" is only in the key, not the value
+      const output = (console.log as Mock).mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(output).toContain('No matches');
+    });
+
+    it('finds value match with values filter', () => {
+      storeState.entries = { server: { ip: '10.0.0.1' } };
+
+      searchEntries('10.0', { values: true });
+
+      const output = (console.log as Mock).mock.calls.map((c: unknown[]) => c.join(' ')).join('\n');
+      expect(output).toContain('server.ip');
+    });
+  });
+
   describe('runCommand --source mode', () => {
     let stderrWriteSpy: SpyInstance;
     let stdoutWriteSpy: SpyInstance;

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -64,9 +64,12 @@ vi.mock('fs', () => {
 vi.mock('../store', () => {
   // Deep clone helper to prevent tests from mutating shared state
   const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+  const saveEntries = vi.fn((d: CodexData) => { storeState.entries = clone(d); });
   return {
     loadEntries:        vi.fn(()  => clone(storeState.entries)),
-    saveEntries:        vi.fn((d: CodexData) => { storeState.entries = clone(d); }),
+    saveEntries,
+    saveEntriesAndTouchMeta: vi.fn((d: CodexData) => { saveEntries(d); }),
+    saveEntriesAndRemoveMeta: vi.fn((d: CodexData) => { saveEntries(d); }),
     loadEntriesMerged:  vi.fn(()  => clone(storeState.entries)),
     loadAliasMap:       vi.fn(()  => clone(storeState.aliases)),
     saveAliasMap:       vi.fn((d: Record<string, string>) => { storeState.aliases = clone(d); }),

--- a/src/__tests__/lint.test.ts
+++ b/src/__tests__/lint.test.ts
@@ -1,0 +1,173 @@
+import { lintEntries } from '../commands/lint';
+import { getEntriesFlat } from '../storage';
+import { findProjectFile } from '../store';
+import fs from 'fs';
+
+vi.mock('../storage', () => ({
+  getEntriesFlat: vi.fn(() => ({})),
+}));
+
+vi.mock('../store', () => ({
+  findProjectFile: vi.fn(() => null),
+  clearProjectFileCache: vi.fn(),
+}));
+
+vi.mock('../formatting', () => ({
+  color: {
+    green: (s: string) => `[green]${s}[/green]`,
+    gray: (s: string) => `[gray]${s}[/gray]`,
+    yellow: (s: string) => `[yellow]${s}[/yellow]`,
+    bold: (s: string) => `[bold]${s}[/bold]`,
+  },
+}));
+
+vi.mock('fs', () => ({
+  default: { readFileSync: vi.fn(), existsSync: vi.fn(() => false) },
+  readFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+}));
+
+const mockGetEntriesFlat = vi.mocked(getEntriesFlat);
+const mockFindProjectFile = vi.mocked(findProjectFile);
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('lintEntries', () => {
+  it('reports no issues when all entries use recommended namespaces', () => {
+    mockGetEntriesFlat.mockReturnValue({
+      'project.name': 'test',
+      'commands.build': 'npm run build',
+      'arch.storage': 'unified store',
+    });
+
+    lintEntries();
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No schema issues'));
+  });
+
+  it('flags entries outside recommended namespaces', () => {
+    mockGetEntriesFlat.mockReturnValue({
+      'project.name': 'test',
+      'custom.key': 'value',
+      'random.stuff': 'data',
+    });
+
+    lintEntries();
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('2 entries outside'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('custom'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('random'));
+  });
+
+  it('groups issues by namespace', () => {
+    mockGetEntriesFlat.mockReturnValue({
+      'bad.one': 'a',
+      'bad.two': 'b',
+      'other.thing': 'c',
+    });
+
+    lintEntries();
+
+    // 3 total issues, grouped under "bad" and "other"
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('3 entries'));
+  });
+
+  it('outputs JSON when --json is set', () => {
+    mockGetEntriesFlat.mockReturnValue({
+      'project.name': 'test',
+      'custom.key': 'value',
+    });
+
+    lintEntries({ json: true });
+
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as { issues: Array<{ key: string; namespace: string }>; allowed: string[] };
+    expect(parsed.issues).toHaveLength(1);
+    expect(parsed.issues[0].namespace).toBe('custom');
+    expect(parsed.allowed).toContain('project');
+    expect(parsed.allowed).toContain('commands');
+  });
+
+  it('outputs empty issues array in JSON when all valid', () => {
+    mockGetEntriesFlat.mockReturnValue({ 'project.name': 'test' });
+
+    lintEntries({ json: true });
+
+    const output = (console.log as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const parsed = JSON.parse(output) as { issues: unknown[] };
+    expect(parsed.issues).toHaveLength(0);
+  });
+
+  it('allows system namespace', () => {
+    mockGetEntriesFlat.mockReturnValue({
+      'system.llm.instructions': 'custom prompt',
+    });
+
+    lintEntries();
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No schema issues'));
+  });
+
+  it('supports custom namespaces from _schema in project file', () => {
+    mockFindProjectFile.mockReturnValue('/project/.codexcli.json');
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      entries: {},
+      aliases: {},
+      confirm: {},
+      _schema: { namespaces: ['custom', 'myapp'] },
+    }));
+    mockGetEntriesFlat.mockReturnValue({
+      'custom.key': 'value',
+      'myapp.setting': 'data',
+      'unknown.ns': 'flagged',
+    });
+
+    lintEntries();
+
+    // Only "unknown" should be flagged — custom and myapp are allowed
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('1 entries outside'));
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('unknown'));
+  });
+
+  it('falls back to defaults when _schema has no namespaces', () => {
+    mockFindProjectFile.mockReturnValue('/project/.codexcli.json');
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      entries: {},
+      aliases: {},
+      confirm: {},
+      _schema: {},
+    }));
+    mockGetEntriesFlat.mockReturnValue({ 'custom.key': 'value' });
+
+    lintEntries();
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('1 entries outside'));
+  });
+
+  it('falls back to defaults when project file parse fails', () => {
+    mockFindProjectFile.mockReturnValue('/project/.codexcli.json');
+    mockReadFileSync.mockImplementation(() => { throw new Error('read error'); });
+    mockGetEntriesFlat.mockReturnValue({ 'custom.key': 'value' });
+
+    lintEntries();
+
+    // Should still work with default namespaces
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('1 entries outside'));
+  });
+
+  it('respects --global flag', () => {
+    mockGetEntriesFlat.mockReturnValue({});
+
+    lintEntries({ global: true });
+
+    expect(mockGetEntriesFlat).toHaveBeenCalledWith('global');
+  });
+});

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -182,13 +182,18 @@ vi.mock('../store', () => ({
     Object.keys(mockData).forEach(k => delete mockData[k]);
     Object.assign(mockData, d);
   }),
-  saveEntriesAndTouchMeta: vi.fn((d: any) => {
+  saveEntriesAndTouchMeta: vi.fn((d: any, key: string) => {
     Object.keys(mockData).forEach(k => delete mockData[k]);
     Object.assign(mockData, d);
+    mockMetaData[key] = Date.now();
   }),
-  saveEntriesAndRemoveMeta: vi.fn((d: any) => {
+  saveEntriesAndRemoveMeta: vi.fn((d: any, key: string) => {
     Object.keys(mockData).forEach(k => delete mockData[k]);
     Object.assign(mockData, d);
+    const prefix = key + '.';
+    for (const k of Object.keys(mockMetaData)) {
+      if (k === key || k.startsWith(prefix)) delete mockMetaData[k];
+    }
   }),
   touchMeta: vi.fn(),
   removeMeta: vi.fn(),

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -181,6 +181,10 @@ vi.mock('../store', () => ({
     Object.keys(mockData).forEach(k => delete mockData[k]);
     Object.assign(mockData, d);
   }),
+  touchMeta: vi.fn(),
+  removeMeta: vi.fn(),
+  loadMeta: vi.fn(() => ({})),
+  loadMetaMerged: vi.fn(() => ({})),
 }));
 
 vi.mock('../formatting', () => ({

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -4,7 +4,7 @@
 type ToolHandler = (params: any) => Promise<any>;
 const {
   toolHandlers, mockExecSync, mockFiles, mockWrittenFiles,
-  mockData, mockAliases, mockConfig, mockConfirmKeys,
+  mockData, mockAliases, mockConfig, mockConfirmKeys, mockMetaData,
 } = vi.hoisted(() => ({
   toolHandlers: {} as Record<string, ToolHandler>,
   mockExecSync: vi.fn(),
@@ -14,6 +14,7 @@ const {
   mockAliases: {} as Record<string, string>,
   mockConfig: { colors: true, theme: 'default' } as Record<string, any>,
   mockConfirmKeys: {} as Record<string, true>,
+  mockMetaData: {} as Record<string, number>,
 }));
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => {
@@ -181,10 +182,18 @@ vi.mock('../store', () => ({
     Object.keys(mockData).forEach(k => delete mockData[k]);
     Object.assign(mockData, d);
   }),
+  saveEntriesAndTouchMeta: vi.fn((d: any) => {
+    Object.keys(mockData).forEach(k => delete mockData[k]);
+    Object.assign(mockData, d);
+  }),
+  saveEntriesAndRemoveMeta: vi.fn((d: any) => {
+    Object.keys(mockData).forEach(k => delete mockData[k]);
+    Object.assign(mockData, d);
+  }),
   touchMeta: vi.fn(),
   removeMeta: vi.fn(),
-  loadMeta: vi.fn(() => ({})),
-  loadMetaMerged: vi.fn(() => ({})),
+  loadMeta: vi.fn(() => ({ ...mockMetaData })),
+  loadMetaMerged: vi.fn(() => ({ ...mockMetaData })),
 }));
 
 vi.mock('../formatting', () => ({
@@ -222,6 +231,7 @@ function resetMocks() {
   Object.assign(mockConfig, { colors: true, theme: 'default' });
   Object.keys(mockFiles).forEach(k => delete mockFiles[k]);
   Object.keys(mockWrittenFiles).forEach(k => delete mockWrittenFiles[k]);
+  Object.keys(mockMetaData).forEach(k => delete mockMetaData[k]);
   mockExecSync.mockReset();
 }
 
@@ -890,6 +900,72 @@ describe('MCP Server Tools', () => {
       const result = await toolHandlers['codex_search']({ searchTerm: 'server', valuesOnly: true });
       // "server" is only in the key, not the value — so no match with valuesOnly
       expect(result.content[0].text).toContain('No results');
+    });
+
+    it('returns error when keysOnly and valuesOnly are both true', async () => {
+      Object.assign(mockData, { server: { ip: '10.0.0.1' } });
+
+      const result = await toolHandlers['codex_search']({ searchTerm: 'server', keysOnly: true, valuesOnly: true });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('mutually exclusive');
+    });
+  });
+
+  describe('codex_stale', () => {
+    it('returns message when no stale entries (default threshold)', async () => {
+      Object.assign(mockData, { project: { name: 'test' } });
+      // All entries have recent timestamps (within last 30 days)
+      const recentTs = Date.now() - 1 * 86400000; // 1 day ago
+      Object.assign(mockMetaData, { 'project.name': recentTs });
+
+      const result = await toolHandlers['codex_stale']({});
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('No entries older than 30 days');
+    });
+
+    it('returns stale entries older than threshold', async () => {
+      Object.assign(mockData, { project: { name: 'test', oldkey: 'oldval' } });
+      const oldTs = Date.now() - 60 * 86400000; // 60 days ago
+      const recentTs = Date.now() - 1 * 86400000; // 1 day ago
+      Object.assign(mockMetaData, {
+        'project.name': recentTs,
+        'project.oldkey': oldTs,
+      });
+
+      const result = await toolHandlers['codex_stale']({ days: 30 });
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('project.oldkey');
+      expect(result.content[0].text).not.toContain('project.name');
+    });
+
+    it('uses custom days threshold', async () => {
+      Object.assign(mockData, { project: { a: '1', b: '2' } });
+      const ts7dAgo = Date.now() - 7 * 86400000;
+      Object.assign(mockMetaData, {
+        'project.a': ts7dAgo,
+        'project.b': ts7dAgo,
+      });
+
+      const result = await toolHandlers['codex_stale']({ days: 3 });
+      expect(result.content[0].text).toContain('project.a');
+      expect(result.content[0].text).toContain('project.b');
+    });
+
+    it('marks entries with no timestamp as never tracked', async () => {
+      Object.assign(mockData, { untracked: 'value' });
+      // mockMetaData is empty (no timestamps)
+
+      const result = await toolHandlers['codex_stale']({ days: 0 });
+      expect(result.content[0].text).toContain('never tracked');
+    });
+
+    it('handles scoped (global) request', async () => {
+      Object.assign(mockData, { g: 'val' });
+      const oldTs = Date.now() - 90 * 86400000;
+      Object.assign(mockMetaData, { g: oldTs });
+
+      const result = await toolHandlers['codex_stale']({ days: 30, scope: 'global' });
+      expect(result.content[0].text).toContain('g');
     });
   });
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -824,4 +824,73 @@ describe('MCP Server Tools', () => {
     });
   });
 
+  describe('codex_run with chain', () => {
+    it('resolves chain keys and joins with &&', async () => {
+      Object.assign(mockData, {
+        cmd: { a: 'echo step-a', b: 'echo step-b' },
+        macros: { both: 'cmd.a cmd.b' },
+      });
+      mockExecSync.mockReturnValue('step-a\nstep-b\n');
+
+      const result = await toolHandlers['codex_run']({ key: 'macros.both', chain: true });
+      expect(result.content[0].text).toContain('echo step-a && echo step-b');
+    });
+
+    it('supports dry run with chain', async () => {
+      Object.assign(mockData, {
+        cmd: { a: 'echo hi', b: 'echo bye' },
+        macros: { both: 'cmd.a cmd.b' },
+      });
+
+      const result = await toolHandlers['codex_run']({ key: 'macros.both', chain: true, dry: true });
+      expect(result.content[0].text).toBe('$ echo hi && echo bye');
+      expect(mockExecSync).not.toHaveBeenCalled();
+    });
+
+    it('returns error when a chain key is not found', async () => {
+      Object.assign(mockData, {
+        macros: { bad: 'cmd.exists cmd.missing' },
+        cmd: { exists: 'echo ok' },
+      });
+
+      const result = await toolHandlers['codex_run']({ key: 'macros.bad', chain: true });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("'cmd.missing' not found");
+    });
+  });
+
+  describe('codex_search with regex', () => {
+    it('matches entries by regex pattern', async () => {
+      Object.assign(mockData, {
+        server: { prod: { ip: '10.0.0.1' }, dev: { ip: '127.0.0.1' } },
+      });
+
+      const result = await toolHandlers['codex_search']({ searchTerm: 'prod.*ip', regex: true });
+      expect(result.content[0].text).toContain('server.prod.ip');
+      expect(result.content[0].text).not.toContain('server.dev.ip');
+    });
+
+    it('returns error for invalid regex', async () => {
+      const result = await toolHandlers['codex_search']({ searchTerm: '[invalid', regex: true });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid regex');
+    });
+
+    it('supports keysOnly', async () => {
+      Object.assign(mockData, { server: { ip: '10.0.0.1' } });
+
+      const result = await toolHandlers['codex_search']({ searchTerm: '10.0', keysOnly: true });
+      // 10.0 is only in the value, not the key — so no match with keysOnly
+      expect(result.content[0].text).toContain('No results');
+    });
+
+    it('supports valuesOnly', async () => {
+      Object.assign(mockData, { server: { ip: '10.0.0.1' } });
+
+      const result = await toolHandlers['codex_search']({ searchTerm: 'server', valuesOnly: true });
+      // "server" is only in the key, not the value — so no match with valuesOnly
+      expect(result.content[0].text).toContain('No results');
+    });
+  });
+
 });

--- a/src/__tests__/storeMeta.test.ts
+++ b/src/__tests__/storeMeta.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+let tmpDir: string;
+let dataPath: string;
+
+vi.mock('../utils/paths', () => ({
+  getDataDirectory: () => tmpDir,
+  getUnifiedDataFilePath: () => path.join(tmpDir, 'data.json'),
+  getAliasFilePath: () => path.join(tmpDir, 'aliases.json'),
+  getConfirmFilePath: () => path.join(tmpDir, 'confirm.json'),
+  ensureDataDirectoryExists: () => {
+    if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+  },
+  findProjectFile: () => null,
+  clearProjectFileCache: () => {},
+}));
+
+import { loadMeta, touchMeta, removeMeta, loadEntries, saveEntries, clearStoreCaches } from '../store';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-meta-'));
+  dataPath = path.join(tmpDir, 'data.json');
+  clearStoreCaches();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('store meta operations', () => {
+  it('touchMeta writes a timestamp for the key', () => {
+    fs.writeFileSync(dataPath, JSON.stringify({ entries: { foo: 'bar' }, aliases: {}, confirm: {} }));
+    clearStoreCaches();
+
+    touchMeta('foo', 'global');
+
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8')) as Record<string, unknown>;
+    const meta = data._meta as Record<string, number>;
+    expect(meta.foo).toBeGreaterThan(0);
+  });
+
+  it('loadMeta returns stored timestamps', () => {
+    const now = Date.now();
+    fs.writeFileSync(dataPath, JSON.stringify({
+      entries: { foo: 'bar' },
+      aliases: {},
+      confirm: {},
+      _meta: { foo: now },
+    }));
+    clearStoreCaches();
+
+    const meta = loadMeta('global');
+    expect(meta.foo).toBe(now);
+  });
+
+  it('loadMeta returns empty object when no _meta exists', () => {
+    fs.writeFileSync(dataPath, JSON.stringify({ entries: {}, aliases: {}, confirm: {} }));
+    clearStoreCaches();
+
+    const meta = loadMeta('global');
+    expect(meta).toEqual({});
+  });
+
+  it('removeMeta deletes key and children', () => {
+    fs.writeFileSync(dataPath, JSON.stringify({
+      entries: {},
+      aliases: {},
+      confirm: {},
+      _meta: { 'server': 100, 'server.ip': 200, 'server.port': 300, 'other': 400 },
+    }));
+    clearStoreCaches();
+
+    removeMeta('server', 'global');
+
+    const meta = loadMeta('global');
+    expect(meta.server).toBeUndefined();
+    expect(meta['server.ip']).toBeUndefined();
+    expect(meta['server.port']).toBeUndefined();
+    expect(meta.other).toBe(400);
+  });
+
+  it('_meta is preserved through save/load cycle', () => {
+    const now = Date.now();
+    fs.writeFileSync(dataPath, JSON.stringify({
+      entries: { foo: 'bar' },
+      aliases: {},
+      confirm: {},
+      _meta: { foo: now },
+    }));
+    clearStoreCaches();
+
+    const entries = loadEntries('global');
+    entries.baz = 'qux';
+    saveEntries(entries, 'global');
+
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8')) as Record<string, unknown>;
+    expect((data._meta as Record<string, number>).foo).toBe(now);
+  });
+
+  it('_meta is not written when empty', () => {
+    fs.writeFileSync(dataPath, JSON.stringify({ entries: { foo: 'bar' }, aliases: {}, confirm: {} }));
+    clearStoreCaches();
+
+    saveEntries({ foo: 'baz' } as Record<string, unknown>, 'global');
+
+    const raw = fs.readFileSync(dataPath, 'utf8');
+    expect(raw).not.toContain('_meta');
+  });
+});

--- a/src/commands/entries.ts
+++ b/src/commands/entries.ts
@@ -30,6 +30,11 @@ export async function runCommand(keys: string[], options: { yes?: boolean, dry?:
   try {
     // --chain: resolve the first key's value as a space-separated list of key references
     if (options.chain) {
+      if (keys.length !== 1) {
+        printError('--chain requires exactly one key argument.');
+        process.exitCode = 1;
+        return;
+      }
       const chainKey = keys[0];
       const resolvedChainKey = resolveKey(chainKey, scope);
       const chainValue = getValue(resolvedChainKey, scope);

--- a/src/commands/entries.ts
+++ b/src/commands/entries.ts
@@ -24,10 +24,37 @@ function toScope(global?: boolean | undefined): Scope | undefined {
   return global ? 'global' : undefined;
 }
 
-export async function runCommand(keys: string[], options: { yes?: boolean, dry?: boolean, decrypt?: boolean, source?: boolean, capture?: boolean, global?: boolean }): Promise<void> {
+export async function runCommand(keys: string[], options: { yes?: boolean, dry?: boolean, decrypt?: boolean, source?: boolean, capture?: boolean, chain?: boolean, global?: boolean }): Promise<void> {
   debug('runCommand called', { keys, options });
   const scope = toScope(options.global);
   try {
+    // --chain: resolve the first key's value as a space-separated list of key references
+    if (options.chain) {
+      const chainKey = keys[0];
+      const resolvedChainKey = resolveKey(chainKey, scope);
+      const chainValue = getValue(resolvedChainKey, scope);
+      if (chainValue === undefined) {
+        printError(`Entry '${chainKey}' not found.`);
+        process.exitCode = 1;
+        return;
+      }
+      if (typeof chainValue !== 'string') {
+        printError(`Entry '${chainKey}' is not a string value.`);
+        process.exitCode = 1;
+        return;
+      }
+      // Split on whitespace to get key references, then run them as if passed as CLI args
+      const chainKeys = chainValue.trim().split(/\s+/);
+      if (chainKeys.length === 0 || (chainKeys.length === 1 && chainKeys[0] === '')) {
+        printError(`Entry '${chainKey}' is empty.`);
+        process.exitCode = 1;
+        return;
+      }
+      debug('chain resolved', { chainKey, chainKeys });
+      // Recurse without --chain to run the resolved keys normally
+      return runCommand(chainKeys, { ...options, chain: false });
+    }
+
     const commands: string[] = [];
     const resolvedKeys: string[] = [];
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,3 +3,4 @@ export { searchEntries } from './search';
 export { exportData, importData, resetData, handleProjectFile } from './data-management';
 export { handleConfig, configSet } from './config-commands';
 export { showInfo } from './info';
+export { lintEntries } from './lint';

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,0 +1,76 @@
+import { getEntriesFlat, Scope } from '../storage';
+import { color } from '../formatting';
+import { findProjectFile } from '../store';
+import fs from 'fs';
+
+const DEFAULT_NAMESPACES = ['project', 'commands', 'arch', 'conventions', 'context', 'files', 'deps', 'system'];
+
+function loadCustomSchema(): string[] | null {
+  const projectFile = findProjectFile();
+  if (!projectFile) return null;
+  try {
+    const raw = JSON.parse(fs.readFileSync(projectFile, 'utf8')) as Record<string, unknown>;
+    const schema = raw._schema as { namespaces?: string[] } | undefined;
+    return schema?.namespaces ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface LintResult {
+  key: string;
+  namespace: string;
+  message: string;
+}
+
+export function lintEntries(options: { json?: boolean; global?: boolean } = {}): void {
+  const scope: Scope | undefined = options.global ? 'global' : undefined;
+  const flat = getEntriesFlat(scope);
+
+  const customNamespaces = loadCustomSchema();
+  const allowedNamespaces = customNamespaces
+    ? [...new Set([...DEFAULT_NAMESPACES, ...customNamespaces])]
+    : DEFAULT_NAMESPACES;
+
+  const issues: LintResult[] = [];
+
+  for (const key of Object.keys(flat)) {
+    const ns = key.split('.')[0];
+    if (!allowedNamespaces.includes(ns)) {
+      issues.push({
+        key,
+        namespace: ns,
+        message: `Namespace '${ns}' is not in the recommended schema`,
+      });
+    }
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ issues, allowed: allowedNamespaces }, null, 2));
+    return;
+  }
+
+  if (issues.length === 0) {
+    console.log(color.green('No schema issues found.'));
+    console.log(color.gray(`Allowed namespaces: ${allowedNamespaces.join(', ')}`));
+    return;
+  }
+
+  // Group by namespace
+  const byNamespace = new Map<string, string[]>();
+  for (const { key, namespace } of issues) {
+    if (!byNamespace.has(namespace)) byNamespace.set(namespace, []);
+    byNamespace.get(namespace)!.push(key);
+  }
+
+  console.log(color.bold(`\n${issues.length} entries outside recommended namespaces:\n`));
+  for (const [ns, keys] of byNamespace) {
+    console.log(`  ${color.yellow(ns)} (${keys.length} entries)`);
+    for (const key of keys) {
+      console.log(`    ${color.gray(key)}`);
+    }
+  }
+  console.log(color.gray(`\nAllowed namespaces: ${allowedNamespaces.join(', ')}`));
+  console.log(color.gray('Add custom namespaces via _schema.namespaces in .codexcli.json'));
+  console.log('');
+}

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -10,8 +10,13 @@ import { interpolate } from '../utils/interpolate';
 
 type MatchFn = (text: string) => boolean;
 
+const MAX_REGEX_LENGTH = 500;
+
 function buildMatcher(searchTerm: string, useRegex: boolean): MatchFn {
   if (useRegex) {
+    if (searchTerm.length > MAX_REGEX_LENGTH) {
+      throw new Error(`Regex pattern too long (max ${MAX_REGEX_LENGTH} characters)`);
+    }
     const re = new RegExp(searchTerm, 'i');
     return (text: string) => re.test(text);
   }
@@ -88,6 +93,13 @@ function displaySearchResults(
 
 export function searchEntries(searchTerm: string, options: SearchOptions = {}): void {
   debug('searchEntries called', { searchTerm, options });
+
+  if (options.keys && options.values) {
+    console.error('Error: --keys and --values are mutually exclusive.');
+    process.exitCode = 1;
+    return;
+  }
+
   const scope = options.global ? 'global' as const : undefined;
   const flattenedData = options.aliases ? {} : getEntriesFlat(scope);
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -8,7 +8,18 @@ import { isEncrypted } from '../utils/crypto';
 import { debug } from '../utils/debug';
 import { interpolate } from '../utils/interpolate';
 
-function searchDataEntries(flattenedData: Record<string, string>, lcSearchTerm: string): Record<string, string> {
+type MatchFn = (text: string) => boolean;
+
+function buildMatcher(searchTerm: string, useRegex: boolean): MatchFn {
+  if (useRegex) {
+    const re = new RegExp(searchTerm, 'i');
+    return (text: string) => re.test(text);
+  }
+  const lc = searchTerm.toLowerCase();
+  return (text: string) => text.toLowerCase().includes(lc);
+}
+
+function searchDataEntries(flattenedData: Record<string, string>, match: MatchFn, keysOnly?: boolean, valuesOnly?: boolean): Record<string, string> {
   const matches: Record<string, string> = {};
   for (const [key, value] of Object.entries(flattenedData)) {
     const encrypted = isEncrypted(value);
@@ -16,8 +27,8 @@ function searchDataEntries(flattenedData: Record<string, string>, lcSearchTerm: 
     if (!encrypted) {
       try { resolved = interpolate(value); } catch { /* use raw */ }
     }
-    const keyMatches = key.toLowerCase().includes(lcSearchTerm);
-    const valueMatches = !encrypted && resolved.toLowerCase().includes(lcSearchTerm);
+    const keyMatches = !valuesOnly && match(key);
+    const valueMatches = !keysOnly && !encrypted && match(resolved);
 
     if (keyMatches || valueMatches) {
       matches[key] = encrypted ? '[encrypted]' : resolved;
@@ -26,13 +37,10 @@ function searchDataEntries(flattenedData: Record<string, string>, lcSearchTerm: 
   return matches;
 }
 
-function searchAliasEntries(aliases: Record<string, string>, lcSearchTerm: string): Record<string, string> {
+function searchAliasEntries(aliases: Record<string, string>, match: MatchFn): Record<string, string> {
   const matches: Record<string, string> = {};
   for (const [aliasName, targetPath] of Object.entries(aliases)) {
-    const nameMatches = aliasName.toLowerCase().includes(lcSearchTerm);
-    const pathMatches = targetPath.toLowerCase().includes(lcSearchTerm);
-
-    if (nameMatches || pathMatches) {
+    if (match(aliasName) || match(targetPath)) {
       matches[aliasName] = targetPath;
     }
   }
@@ -88,11 +96,18 @@ export function searchEntries(searchTerm: string, options: SearchOptions = {}): 
     return;
   }
 
-  const lcSearchTerm = searchTerm.toLowerCase();
+  let match: MatchFn;
+  try {
+    match = buildMatcher(searchTerm, !!options.regex);
+  } catch (err) {
+    console.error(`Invalid regex: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+    return;
+  }
 
   const aliases = loadAliases(scope);
-  const dataMatches = options.aliases ? {} : searchDataEntries(flattenedData, lcSearchTerm);
-  const aliasMatches = options.entries ? {} : searchAliasEntries(aliases, lcSearchTerm);
+  const dataMatches = options.aliases ? {} : searchDataEntries(flattenedData, match, options.keys, options.values);
+  const aliasMatches = options.entries ? {} : searchAliasEntries(aliases, match);
 
   const totalMatches = Object.keys(dataMatches).length + Object.keys(aliasMatches).length;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,8 +158,9 @@ codexCLI
   .option('-d, --decrypt', 'Decrypt an encrypted command before running')
   .option('-c, --capture', 'Capture output for piping (instead of inheriting stdio)')
   .option('--source', 'Output command to stdout for shell eval (used by shell wrapper)')
+  .option('--chain', 'Treat stored value as space-separated key references to resolve and chain')
   .option('-G, --global', 'Target global data store')
-  .action(async (keys: string[], options: { yes?: boolean, dry?: boolean, decrypt?: boolean, capture?: boolean, source?: boolean, global?: boolean }) => {
+  .action(async (keys: string[], options: { yes?: boolean, dry?: boolean, decrypt?: boolean, capture?: boolean, source?: boolean, chain?: boolean, global?: boolean }) => {
     await commands.runCommand(keys, options);
   });
 
@@ -183,15 +184,12 @@ codexCLI
   .option('-a, --aliases', 'Search only in aliases')
   .option('-t, --tree', 'Display results in a hierarchical tree structure')
   .option('-j, --json', 'Output as JSON (for scripting)')
+  .option('-x, --regex', 'Treat search term as a regular expression')
+  .option('-k, --keys', 'Search keys only (skip value matching)')
+  .option('-v, --values', 'Search values only (skip key matching)')
   .option('-G, --global', 'Target global data store')
-  .action(async (term: string, options: { entries?: boolean, aliases?: boolean, tree?: boolean, json?: boolean, global?: boolean }) => {
-    await withPager(() => commands.searchEntries(term, {
-      entries: options.entries,
-      aliases: options.aliases,
-      tree: options.tree,
-      json: options.json,
-      global: options.global,
-    }));
+  .action(async (term: string, options: { entries?: boolean, aliases?: boolean, tree?: boolean, json?: boolean, regex?: boolean, keys?: boolean, values?: boolean, global?: boolean }) => {
+    await withPager(() => commands.searchEntries(term, options));
   });
 
 // Edit command
@@ -242,6 +240,55 @@ codexCLI
     } else {
       await commands.removeEntry(resolveKey(key), options.force, options.global);
     }
+  });
+
+// Stale entries command
+codexCLI
+  .command('stale [days]')
+  .description('Show entries not updated in N days (default: 30)')
+  .option('-j, --json', 'Output as JSON')
+  .option('-G, --global', 'Target global data store')
+  .action(async (days: string | undefined, options: { json?: boolean, global?: boolean }) => {
+    const { loadMeta, loadMetaMerged } = await import('./store');
+    const { getEntriesFlat } = await import('./storage');
+    const { color } = await import('./formatting');
+    const threshold = parseInt(days ?? '30', 10);
+    const scope = options.global ? 'global' as const : undefined;
+    const meta = scope ? loadMeta(scope) : loadMetaMerged();
+    const flat = getEntriesFlat(scope);
+    const cutoff = Date.now() - threshold * 86400000;
+    const stale: Array<{ key: string; age: number; lastUpdated: number | undefined }> = [];
+    for (const key of Object.keys(flat)) {
+      const ts = meta[key];
+      if (ts === undefined || ts < cutoff) {
+        stale.push({ key, age: ts ? Math.floor((Date.now() - ts) / 86400000) : -1, lastUpdated: ts });
+      }
+    }
+    if (options.json) {
+      console.log(JSON.stringify(stale, null, 2));
+      return;
+    }
+    if (stale.length === 0) {
+      console.log(color.green(`No entries older than ${threshold} days.`));
+      return;
+    }
+    console.log(color.bold(`\n${stale.length} entries not updated in ${threshold}+ days:\n`));
+    for (const { key, age } of stale) {
+      const ageStr = age < 0 ? 'never tracked' : `${age}d ago`;
+      const ageColor = age < 0 ? color.gray : age > 90 ? color.red : color.yellow;
+      console.log(`  ${color.white(key.padEnd(40))} ${ageColor(ageStr)}`);
+    }
+    console.log('');
+  });
+
+// Lint command
+codexCLI
+  .command('lint')
+  .description('Check entries against the recommended namespace schema')
+  .option('-j, --json', 'Output as JSON')
+  .option('-G, --global', 'Target global data store')
+  .action((options: { json?: boolean, global?: boolean }) => {
+    commands.lintEntries(options);
   });
 
 // Configuration commands

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,6 +254,11 @@ codexCLI
     const { getEntriesFlat } = await import('./storage');
     const { color } = await import('./formatting');
     const threshold = parseInt(days ?? '30', 10);
+    if (isNaN(threshold) || threshold < 0) {
+      console.error(color.red('Error: days must be a non-negative integer.'));
+      process.exitCode = 1;
+      return;
+    }
     const scope = options.global ? 'global' as const : undefined;
     const meta = scope ? loadMeta(scope) : loadMetaMerged();
     const flat = getEntriesFlat(scope);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -443,10 +443,16 @@ server.tool(
   },
   async ({ searchTerm, regex, keysOnly, valuesOnly, aliasesOnly, entriesOnly, scope: scopeParam }) => {
     try {
+      if (keysOnly && valuesOnly) {
+        return errorResponse("'keysOnly' and 'valuesOnly' are mutually exclusive.");
+      }
       const scope = toScope(scopeParam);
       let match: (text: string) => boolean;
       try {
         if (regex) {
+          if (searchTerm.length > 500) {
+            return errorResponse("Regex pattern too long (max 500 characters).");
+          }
           const re = new RegExp(searchTerm, 'i');
           match = (text: string) => re.test(text);
         } else {
@@ -578,7 +584,14 @@ server.tool(
 
     // --chain: split value into key references, resolve each, and &&-chain
     if (chain) {
-      const chainKeys = value.trim().split(/\s+/);
+      const trimmedValue = value.trim();
+      if (!trimmedValue) {
+        return errorResponse(`Value at '${key}' is empty and cannot be used with chain mode.`);
+      }
+      const chainKeys = trimmedValue.split(/\s+/).filter(Boolean);
+      if (chainKeys.length === 0) {
+        return errorResponse(`Value at '${key}' is empty and cannot be used with chain mode.`);
+      }
       const commands: string[] = [];
       for (const ck of chainKeys) {
         const rk = resolveKey(ck, scope);
@@ -975,7 +988,7 @@ server.tool(
   "codex_stale",
   "Find entries that haven't been updated recently (helps identify stale knowledge)",
   {
-    days: z.number().optional().describe("Threshold in days (default: 30). Entries not updated in this many days are returned."),
+    days: z.number().int().min(0).optional().describe("Threshold in days (default: 30). Entries not updated in this many days are returned."),
     scope: z.enum(["project", "global"]).optional().describe("Data scope (omit for auto: project if available, else global)"),
   },
   async ({ days, scope: scopeParam }) => {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -589,9 +589,6 @@ server.tool(
         return errorResponse(`Value at '${key}' is empty and cannot be used with chain mode.`);
       }
       const chainKeys = trimmedValue.split(/\s+/).filter(Boolean);
-      if (chainKeys.length === 0) {
-        return errorResponse(`Value at '${key}' is empty and cannot be used with chain mode.`);
-      }
       const commands: string[] = [];
       for (const ck of chainKeys) {
         const rk = resolveKey(ck, scope);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -474,24 +474,37 @@ server.tool(
   "codex_search",
   "Search entries in the CodexCLI data store",
   {
-    searchTerm: z.string().describe("Term to search for (case-insensitive)"),
+    searchTerm: z.string().describe("Term to search for (case-insensitive substring, or regex if regex=true)"),
+    regex: z.boolean().optional().describe("Treat searchTerm as a regular expression"),
+    keysOnly: z.boolean().optional().describe("Match against keys only (skip values)"),
+    valuesOnly: z.boolean().optional().describe("Match against values only (skip keys)"),
     aliasesOnly: z.boolean().optional().describe("Search only in aliases"),
     entriesOnly: z.boolean().optional().describe("Search only in data entries"),
     scope: z.enum(["project", "global"]).optional().describe("Data scope (omit for auto: project if available, else global)"),
   },
-  async ({ searchTerm, aliasesOnly, entriesOnly, scope: scopeParam }) => {
+  async ({ searchTerm, regex, keysOnly, valuesOnly, aliasesOnly, entriesOnly, scope: scopeParam }) => {
     try {
       const scope = toScope(scopeParam);
-      const term = searchTerm.toLowerCase();
+      let match: (text: string) => boolean;
+      try {
+        if (regex) {
+          const re = new RegExp(searchTerm, 'i');
+          match = (text: string) => re.test(text);
+        } else {
+          const lc = searchTerm.toLowerCase();
+          match = (text: string) => text.toLowerCase().includes(lc);
+        }
+      } catch (err) {
+        return errorResponse(`Invalid regex: ${err instanceof Error ? err.message : String(err)}`);
+      }
       const results: string[] = [];
 
       if (!aliasesOnly) {
-
         const flat = getEntriesFlat(scope);
         for (const [k, v] of Object.entries(flat)) {
           const encrypted = isEncrypted(v);
-          const keyMatch = k.toLowerCase().includes(term);
-          const valueMatch = !encrypted && String(v).toLowerCase().includes(term);
+          const keyMatch = !valuesOnly && match(k);
+          const valueMatch = !keysOnly && !encrypted && match(String(v));
 
           if (keyMatch || valueMatch) {
             results.push(`${k}: ${encrypted ? '[encrypted]' : v}`);
@@ -502,10 +515,7 @@ server.tool(
       if (!entriesOnly) {
         const aliases = loadAliases(scope);
         for (const [alias, target] of Object.entries(aliases)) {
-          if (
-            alias.toLowerCase().includes(term) ||
-            target.toLowerCase().includes(term)
-          ) {
+          if (match(alias) || match(target)) {
             results.push(`[alias] ${alias} -> ${target}`);
           }
         }
@@ -591,10 +601,11 @@ server.tool(
     key: z.string().describe("Dot-notation key (or alias) whose value is a shell command"),
     dry: z.boolean().optional().describe("If true, return the command without executing it"),
     force: z.boolean().optional().describe("If true, skip the confirm check for entries marked --confirm"),
+    chain: z.boolean().optional().describe("If true, treat stored value as space-separated key references to resolve and &&-chain"),
     capture: z.boolean().optional().describe("Capture output (MCP always captures; included for API consistency)"),
     scope: z.enum(["project", "global"]).optional().describe("Data scope (omit for auto: project if available, else global)"),
   },
-  async ({ key, dry, force, scope: scopeParam }) => {
+  async ({ key, dry, force, chain, scope: scopeParam }) => {
     const scope = toScope(scopeParam);
     const resolvedKey = resolveKey(key, scope);
     const value = getValue(resolvedKey, scope);
@@ -604,6 +615,37 @@ server.tool(
     }
     if (typeof value !== "string") {
       return errorResponse(`Value at '${key}' is not a string command.`);
+    }
+
+    // --chain: split value into key references, resolve each, and &&-chain
+    if (chain) {
+      const chainKeys = value.trim().split(/\s+/);
+      const commands: string[] = [];
+      for (const ck of chainKeys) {
+        const rk = resolveKey(ck, scope);
+        const cv = getValue(rk, scope);
+        if (cv === undefined) return errorResponse(`Chain key '${ck}' not found.`);
+        if (typeof cv !== 'string') return errorResponse(`Chain key '${ck}' is not a string command.`);
+        if (isEncrypted(cv)) return errorResponse(`Chain key '${ck}' is encrypted.`);
+        if (hasConfirm(rk) && !force && !dry) {
+          return errorResponse(`Chain key '${ck}' requires confirmation. Pass force: true.`);
+        }
+        try { commands.push(interpolate(cv)); } catch (err) {
+          return errorResponse(`Interpolation error in '${ck}': ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      const command = commands.join(' && ');
+      if (dry) return textResponse(`$ ${command}`);
+      try {
+        const stdout = execSync(command, { encoding: "utf-8", shell: process.env.SHELL ?? "/bin/sh", timeout: 30000 });
+        return textResponse(`$ ${command}\n${stdout}`);
+      } catch (err: unknown) {
+        if (err && typeof err === "object" && "status" in err) {
+          const execErr = err as { status: number; stderr?: string };
+          return errorResponse(`$ ${command}\nCommand failed (exit ${execErr.status}): ${execErr.stderr ?? ""}`);
+        }
+        return errorResponse(`Error running command: ${String(err)}`);
+      }
     }
 
     if (isEncrypted(value)) {
@@ -935,11 +977,22 @@ server.tool(
         return textResponse("No entries stored. Use codex_set to add project knowledge.");
       }
 
+      // Load meta for age indicators
+      const { loadMeta, loadMetaMerged } = await import("./store");
+      const meta = effectiveScope === 'auto' ? loadMetaMerged() : loadMeta(effectiveScope);
+      const STALE_DAYS = 30;
+      const staleCutoff = Date.now() - STALE_DAYS * 86400000;
+
       const lines: string[] = [];
 
       if (Object.keys(flat).length > 0) {
         for (const [k, v] of Object.entries(flat)) {
-          lines.push(`${k}: ${isEncrypted(v) ? '[encrypted]' : v}`);
+          const ts = meta[k];
+          let ageTag = '';
+          if (ts !== undefined && ts < staleCutoff) {
+            ageTag = ` [${Math.floor((Date.now() - ts) / 86400000)}d]`;
+          }
+          lines.push(`${k}: ${isEncrypted(v) ? '[encrypted]' : v}${ageTag}`);
         }
       }
 
@@ -954,6 +1007,42 @@ server.tool(
       return textResponse(lines.join("\n"));
     } catch (err) {
       return errorResponse(`Error loading context: ${String(err)}`);
+    }
+  }
+);
+
+// --- codex_stale ---
+server.tool(
+  "codex_stale",
+  "Find entries that haven't been updated recently (helps identify stale knowledge)",
+  {
+    days: z.number().optional().describe("Threshold in days (default: 30). Entries not updated in this many days are returned."),
+    scope: z.enum(["project", "global"]).optional().describe("Data scope (omit for auto: project if available, else global)"),
+  },
+  async ({ days, scope: scopeParam }) => {
+    try {
+      const threshold = days ?? 30;
+      const scope = toScope(scopeParam);
+      const { loadMeta, loadMetaMerged } = await import("./store");
+      const meta = scope === 'auto' ? loadMetaMerged() : loadMeta(scope);
+      const flat = getEntriesFlat(scope);
+      const cutoff = Date.now() - threshold * 86400000;
+
+      const stale: string[] = [];
+      for (const key of Object.keys(flat)) {
+        const ts = meta[key];
+        if (ts === undefined || ts < cutoff) {
+          const age = ts ? `${Math.floor((Date.now() - ts) / 86400000)}d ago` : 'never tracked';
+          stale.push(`${key}  (${age})`);
+        }
+      }
+
+      if (stale.length === 0) {
+        return textResponse(`No entries older than ${threshold} days.`);
+      }
+      return textResponse(`${stale.length} entries not updated in ${threshold}+ days:\n${stale.join('\n')}`);
+    } catch (err) {
+      return errorResponse(`Error checking staleness: ${String(err)}`);
     }
   }
 );

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,7 +2,7 @@ import { color } from './formatting';
 import { getNestedValue, setNestedValue, removeNestedValue, flattenObject } from './utils/objectPath';
 import { CodexData, CodexValue } from './types';
 import { debug } from './utils/debug';
-import { Scope, loadEntries, saveEntries, loadEntriesMerged, findProjectFile, touchMeta, removeMeta } from './store';
+import { Scope, loadEntries, saveEntries, loadEntriesMerged, findProjectFile, saveEntriesAndTouchMeta, saveEntriesAndRemoveMeta } from './store';
 
 export { Scope } from './store';
 
@@ -73,8 +73,7 @@ export function setValue(key: string, value: string, scope?: Scope | undefined):
   const effectiveScope = scope ?? 'auto';
   const data = loadEntries(effectiveScope);
   setNestedValue(data, key, value);
-  saveEntries(data, effectiveScope);
-  touchMeta(key, effectiveScope);
+  saveEntriesAndTouchMeta(data, key, effectiveScope);
 }
 
 /**
@@ -88,8 +87,7 @@ export function removeValue(key: string, scope?: Scope | undefined): boolean {
       if (getNestedValue(projectData, key) !== undefined) {
         const removed = removeNestedValue(projectData, key);
         if (removed) {
-          saveEntries(projectData, 'project');
-          removeMeta(key, 'project');
+          saveEntriesAndRemoveMeta(projectData, key, 'project');
         }
         return removed;
       }
@@ -98,8 +96,7 @@ export function removeValue(key: string, scope?: Scope | undefined): boolean {
     const globalData = loadEntries('global');
     const removed = removeNestedValue(globalData, key);
     if (removed) {
-      saveEntries(globalData, 'global');
-      removeMeta(key, 'global');
+      saveEntriesAndRemoveMeta(globalData, key, 'global');
     }
     return removed;
   }
@@ -107,8 +104,7 @@ export function removeValue(key: string, scope?: Scope | undefined): boolean {
   const data = loadEntries(scope);
   const removed = removeNestedValue(data, key);
   if (removed) {
-    saveEntries(data, scope);
-    removeMeta(key, scope);
+    saveEntriesAndRemoveMeta(data, key, scope);
   }
   return removed;
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,7 +2,7 @@ import { color } from './formatting';
 import { getNestedValue, setNestedValue, removeNestedValue, flattenObject } from './utils/objectPath';
 import { CodexData, CodexValue } from './types';
 import { debug } from './utils/debug';
-import { Scope, loadEntries, saveEntries, loadEntriesMerged, findProjectFile } from './store';
+import { Scope, loadEntries, saveEntries, loadEntriesMerged, findProjectFile, touchMeta, removeMeta } from './store';
 
 export { Scope } from './store';
 
@@ -74,6 +74,7 @@ export function setValue(key: string, value: string, scope?: Scope | undefined):
   const data = loadEntries(effectiveScope);
   setNestedValue(data, key, value);
   saveEntries(data, effectiveScope);
+  touchMeta(key, effectiveScope);
 }
 
 /**
@@ -86,20 +87,29 @@ export function removeValue(key: string, scope?: Scope | undefined): boolean {
       const projectData = loadEntries('project');
       if (getNestedValue(projectData, key) !== undefined) {
         const removed = removeNestedValue(projectData, key);
-        if (removed) saveEntries(projectData, 'project');
+        if (removed) {
+          saveEntries(projectData, 'project');
+          removeMeta(key, 'project');
+        }
         return removed;
       }
     }
     // Fall through to global
     const globalData = loadEntries('global');
     const removed = removeNestedValue(globalData, key);
-    if (removed) saveEntries(globalData, 'global');
+    if (removed) {
+      saveEntries(globalData, 'global');
+      removeMeta(key, 'global');
+    }
     return removed;
   }
 
   const data = loadEntries(scope);
   const removed = removeNestedValue(data, key);
-  if (removed) saveEntries(data, scope);
+  if (removed) {
+    saveEntries(data, scope);
+    removeMeta(key, scope);
+  }
   return removed;
 }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,6 +13,7 @@ interface UnifiedData {
   entries: CodexData;
   aliases: Record<string, string>;
   confirm: Record<string, true>;
+  _meta?: Record<string, number> | undefined;
 }
 
 export type Scope = 'project' | 'global' | 'auto';
@@ -59,6 +60,7 @@ function createScopedStore(getFilePath: () => string, ensureDir: () => void): Sc
         entries: (parsed.entries ?? {}) as CodexData,
         aliases: (parsed.aliases ?? {}) as Record<string, string>,
         confirm: (parsed.confirm ?? {}) as Record<string, true>,
+        _meta: (parsed._meta ?? undefined) as Record<string, number> | undefined,
       };
 
       cache = result;
@@ -86,6 +88,9 @@ function createScopedStore(getFilePath: () => string, ensureDir: () => void): Sc
         confirm: Object.fromEntries(Object.entries(data.confirm).sort(([a], [b]) => a.localeCompare(b))),
         entries: data.entries, // entries are nested — saveJsonSorted handles top-level sort
       };
+      if (data._meta && Object.keys(data._meta).length > 0) {
+        sorted._meta = Object.fromEntries(Object.entries(data._meta).sort(([a], [b]) => a.localeCompare(b)));
+      }
       saveJsonSorted(filePath, sorted);
       const mtime = fs.statSync(filePath).mtimeMs;
       cache = data;
@@ -247,6 +252,39 @@ export function clearStoreCaches(): void {
   projectStorePath = null;
   migrationDone = false;
   clearProjectFileCache();
+}
+
+// ── Meta (staleness tracking) ─────────────────────────────────────────
+
+export function loadMeta(scope?: Scope | undefined): Record<string, number> {
+  return resolveStore(scope).load()._meta ?? {};
+}
+
+export function touchMeta(key: string, scope?: Scope | undefined): void {
+  const store = resolveStore(scope);
+  const current = store.load();
+  const meta = { ...(current._meta ?? {}), [key]: Date.now() };
+  store.save({ ...current, _meta: meta });
+}
+
+export function removeMeta(key: string, scope?: Scope | undefined): void {
+  const store = resolveStore(scope);
+  const current = store.load();
+  if (!current._meta) return;
+  const meta = { ...current._meta };
+  // Remove exact key and any children (e.g., removing "server" also removes "server.ip")
+  const prefix = key + '.';
+  for (const k of Object.keys(meta)) {
+    if (k === key || k.startsWith(prefix)) delete meta[k];
+  }
+  store.save({ ...current, _meta: meta });
+}
+
+export function loadMetaMerged(): Record<string, number> {
+  const project = getProjectStore();
+  const global = getGlobalStore();
+  if (!project) return global.load()._meta ?? {};
+  return { ...(global.load()._meta ?? {}), ...(project.load()._meta ?? {}) };
 }
 
 // ── Migration ──────────────────────────────────────────────────────────

--- a/src/store.ts
+++ b/src/store.ts
@@ -280,6 +280,30 @@ export function removeMeta(key: string, scope?: Scope | undefined): void {
   store.save({ ...current, _meta: meta });
 }
 
+/** Save entries and touch _meta[key] in a single write. */
+export function saveEntriesAndTouchMeta(data: CodexData, key: string, scope?: Scope | undefined): void {
+  const store = resolveStore(scope);
+  const current = store.load();
+  const meta = { ...(current._meta ?? {}), [key]: Date.now() };
+  store.save({ ...current, entries: data, _meta: meta });
+}
+
+/** Save entries and remove _meta keys (and children) in a single write. */
+export function saveEntriesAndRemoveMeta(data: CodexData, key: string, scope?: Scope | undefined): void {
+  const store = resolveStore(scope);
+  const current = store.load();
+  if (!current._meta) {
+    store.save({ ...current, entries: data });
+    return;
+  }
+  const meta = { ...current._meta };
+  const prefix = key + '.';
+  for (const k of Object.keys(meta)) {
+    if (k === key || k.startsWith(prefix)) delete meta[k];
+  }
+  store.save({ ...current, entries: data, _meta: meta });
+}
+
 export function loadMetaMerged(): Record<string, number> {
   const project = getProjectStore();
   const global = getGlobalStore();

--- a/src/store.ts
+++ b/src/store.ts
@@ -304,6 +304,7 @@ function migrateToUnifiedFile(): { data: UnifiedData; mtime: number } | null {
           entries: (parsed.entries ?? {}) as CodexData,
           aliases: (parsed.aliases ?? {}) as Record<string, string>,
           confirm: (parsed.confirm ?? {}) as Record<string, true>,
+          _meta: (parsed._meta ?? undefined) as Record<string, number> | undefined,
         },
         mtime: stat.mtimeMs,
       };

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,9 @@ export interface SearchOptions {
   aliases?: boolean | undefined;
   tree?: boolean | undefined;
   json?: boolean | undefined;
+  regex?: boolean | undefined;
+  keys?: boolean | undefined;
+  values?: boolean | undefined;
   global?: boolean | undefined;
 }
 


### PR DESCRIPTION
## Summary

Four features completing the v1.0 roadmap:

### Stored command chains (#16)
```bash
ccli set macros.deploy "commands.build commands.test commands.deploy"
ccli run macros.deploy --chain    # → npm run build && npm test && ./deploy.sh
```
- `--chain` flag on `run` (CLI + MCP `codex_run`)
- Resolves space-separated key references, chains with `&&`
- Works with `--dry`, `--confirm`, `--source`, `--capture`

### Advanced search (#9)
```bash
ccli find "prod.*ip" --regex      # regex patterns
ccli find "server" --keys         # key-only matching
ccli find "10.0" --values         # value-only matching
```
- `--regex` / `-x` flag on `find` (CLI + MCP `codex_search`)
- `--keys` / `--values` for field-specific filtering

### Staleness detection
```bash
ccli stale 14                     # entries not updated in 14 days
```
- `_meta` section in data.json tracks last-modified timestamps per key
- Auto-updated on `setValue`, cleaned on `removeValue`
- `ccli stale [days]` CLI command with color-coded output
- `codex_stale` MCP tool for agents
- `codex_context` appends `[Nd]` age tags for entries >30d old

### Schema validation
```bash
ccli lint                         # check namespace compliance
ccli lint --json                  # machine-readable output
```
- Checks entries against recommended namespaces (project, commands, arch, etc.)
- Custom namespaces via `_schema.namespaces` in `.codexcli.json`

## Test plan
- [x] 4 new command chain tests (resolve, dry run, missing key, missing entry)
- [x] All 505 tests passing
- [x] Smoke tested all four features with real data
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)