### PR TITLE
fix: address v1.10.0 review feedback — security, atomicity, and correctness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,9 @@ data/
 telemetry.jsonl
 audit.jsonl
 
-# Project store (file-per-entry layout migration artifacts)
-.codexcli/
+# Legacy migration artifact — kept out of the committed store.
+# The `.codexcli/` directory itself is intentionally NOT ignored: it's the
+# project knowledge store and is meant to be committed (this is the whole
+# dogfooding premise of the project).
 .codexcli.json.backup
 

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,7 @@ data/
 telemetry.jsonl
 audit.jsonl
 
+# Project store (file-per-entry layout migration artifacts)
+.codexcli/
+.codexcli.json.backup
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Removed
 
 - **`createScopedStore` factory** in `src/store.ts` — replaced entirely by `createDirectoryStore` in `src/utils/directoryStore.ts`. Public API (`loadEntries`, `saveEntries`, `loadMeta`, etc.) is unchanged; only the private implementation behind it.
-- **`ScopedStore.prime()`** — only used by the legacy migration cache, not needed by the new migration path.
+- **`ScopedStore.prime()`** — removed from the interface and implementation. It was a no-op carried forward from the legacy migration cache; the new migration path writes the directory directly and does not need it.
 
 ## [1.9.2] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-04-07
+
+### Changed
+
+- **File-per-entry store layout** — `.codexcli.json` (project) and `~/.codexcli/data.json` (global) are replaced by a `.codexcli/` directory (project) and `~/.codexcli/store/` directory (global). Each entry lives in its own file as `<dotted-key>.json` with a `{value, meta: {created, updated}}` wrapper. Store-level state lives in sidecar files `_aliases.json` and `_confirm.json`. Automatic, idempotent migration runs on first access after upgrade; old files are renamed to `.backup`. No user-visible CLI or MCP changes — the in-memory shape returned by every store-layer function is identical. Closes [#54](https://github.com/seabearDEV/codexCLI/issues/54).
+  - **Why**: the old single-file layout produced merge conflicts for multi-dev projects whenever two developers added different entries on parallel branches — both writes touched the same JSON region and git textual merge fought them. Per-entry files eliminate that entire class of conflicts: git merges the directory file-by-file, so different-key concurrent edits no longer conflict at all, and same-key edits (the rare case where you actually want a human looking) remain visible in the diff.
+  - **`meta.created` from day one** — every entry wrapper gets both `meta.created` (set on first write, preserved across updates) and `meta.updated` (bumped on every write). Migrated entries preserve the legacy `_meta[key]` timestamp as both fields; entries that had no legacy timestamp migrate as `[untracked]` (no `meta` block) so `ccli stale` continues to surface them accurately.
+  - **Hand-editing is unsupported** — the wrapper format assumes only the CLI, MCP tools, or a future UI touch the files. Direct edits desync per-entry metadata (staleness, future provenance fields) and break the wrapper contract. Documented as `conventions.editSurface` in the codex.
+  - **Dirty-tracking save()** — only files whose wrapper changed are rewritten, so single-entry updates touch exactly one file instead of rewriting all N.
+  - **Bulk-op atomicity** — `reset --entries` and `import --replace` build the new state in a sibling `.codexcli.tmp/` directory and swap atomically via double-rename; failure mid-swap leaves the old state intact and is self-cleaned on next startup.
+  - **`autoBackup`** now recursively copies the new store directory via `fs.cpSync`, plus any lingering legacy files as fallback.
+  - **`ccli init`** creates a `.codexcli/` directory (not a file) and seeds empty `_aliases.json` / `_confirm.json` sidecars. `ccli init --remove` and `ccli project --remove` use `fs.rmSync` which handles both the new directory and legacy file uniformly.
+
+### Added
+
+- **`findProjectStoreDir()`** in `src/utils/paths.ts` — purpose-built resolver that walks up looking for a `.codexcli/` directory specifically, used by store internals. `findProjectFile()` remains as the general-purpose "does a project exist, where is it?" query and now recognizes both the new directory and the legacy file, preferring the directory when both exist.
+- **`getGlobalStoreDirPath()`** in `src/utils/paths.ts` — returns `~/.codexcli/store/`, the v1.10.0 global store location.
+- **Design decision entries in the codex** — `arch.storeLayout` captures the decision and rationale; `conventions.editSurface` codifies the "CLI / MCP / future UI only" rule. Future sessions inherit both without relitigating.
+
+### Removed
+
+- **`createScopedStore` factory** in `src/store.ts` — replaced entirely by `createDirectoryStore` in `src/utils/directoryStore.ts`. Public API (`loadEntries`, `saveEntries`, `loadMeta`, etc.) is unchanged; only the private implementation behind it.
+- **`ScopedStore.prime()`** — only used by the legacy migration cache, not needed by the new migration path.
+
 ## [1.9.2] - 2026-04-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Call `codex_context` as your first tool call to load all stored project knowledg
 
 ## Prefer MCP tools over direct file reads
 
-Always use codexCLI MCP tools (`codex_get`, `codex_set`, `codex_search`, etc.) to interact with `.codexcli.json`. Direct file reads bypass audit logging, alias resolution, and interpolation. The only acceptable reason to read `.codexcli.json` directly is debugging the MCP server itself.
+Always use codexCLI MCP tools (`codex_get`, `codex_set`, `codex_search`, etc.) to interact with the project store at `.codexcli/`. Direct file reads bypass audit logging, alias resolution, interpolation, and staleness metadata, and hand-editing `.codexcli/*.json` is **unsupported** — it desyncs per-entry meta and breaks staleness signals (see `conventions.editSurface` in the codex). The supported edit paths are CLI, MCP tools, and (eventually) a dedicated UI.
 
 ## Before exploring code
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ CodexCLI is a command-line tool and AI agent knowledge base. It stores structure
 - **Inline Editing**: Open entries in `$EDITOR` / `$VISUAL` for quick edits
 - **JSON Output**: Machine-readable `--json` flag on `get` and `find` for scripting
 - **Stdin Piping**: Pipe values into `set` from other commands
-- **Project-Scoped Data**: Opt-in `.codexcli.json` per project — project entries take precedence, fall through to global
-- **Smart Init**: `ccli init` scans your codebase, populates `.codexcli.json` with project/commands/files/deps/conventions/context entries, generates `CLAUDE.md`, and seeds the three-file knowledge convention
+- **Project-Scoped Data**: Opt-in `.codexcli/` per project — project entries take precedence, fall through to global
+- **Smart Init**: `ccli init` scans your codebase, populates `.codexcli/` with project/commands/files/deps/conventions/context entries, generates `CLAUDE.md`, and seeds the three-file knowledge convention
 - **Auto-Backup**: Automatic timestamped backups with configurable rotation (`max_backups` setting)
 - **File Locking**: Advisory locking prevents data corruption from concurrent access
 - **Shell Tab-Completion**: Full tab-completion for Bash and Zsh (commands, flags, keys, aliases)
@@ -172,7 +172,7 @@ After setting an entry, you'll be asked interactively whether it should require 
 
 ### Retrieving Data
 
-When inside a project directory (one with a `.codexcli.json`), `get` shows project entries by default. Use `-G` for global entries or `-A` for both. Outside a project, `get` shows global entries. Looking up a specific key always falls through from project to global automatically.
+When inside a project directory (one with a `.codexcli/` store), `get` shows project entries by default. Use `-G` for global entries or `-A` for both. Outside a project, `get` shows global entries. Looking up a specific key always falls through from project to global automatically.
 
 ```bash
 # List keys in the current scope
@@ -511,10 +511,10 @@ Available settings:
 
 ### Project-Scoped Data
 
-CodexCLI supports per-project data files that live alongside your code. The `.codexcli.json` file is designed to be committed to version control, creating a shared knowledge base that persists across sessions, team members, and AI agents.
+CodexCLI supports per-project knowledge stores that live alongside your code. The `.codexcli/` directory is designed to be committed to version control, creating a shared knowledge base that persists across sessions, team members, and AI agents. As of v1.10.0, each entry is its own JSON file inside the directory (`.codexcli/arch.storage.json`, `.codexcli/commands.build.json`, etc.) — this eliminates merge conflict churn when multiple devs add different entries on parallel branches. Use CLI or MCP tools to edit; hand-editing the wrapper files is unsupported.
 
 ```bash
-# Initialize a project — scans codebase, creates .codexcli.json and CLAUDE.md
+# Initialize a project — scans codebase, creates .codexcli/ and CLAUDE.md
 ccli init
 
 # Preview what init would create
@@ -523,7 +523,7 @@ ccli init --dry-run
 # Init without CLAUDE.md generation
 ccli init --no-claude
 
-# Init without codebase scan (empty .codexcli.json)
+# Init without codebase scan (empty .codexcli/)
 ccli init --no-scan
 
 # Store project knowledge
@@ -548,7 +548,7 @@ ccli get -A
 # Use -G to explicitly write to global while inside a project
 ccli set server.ip 192.168.1.100 -G
 
-# Remove the project file
+# Remove the project store
 ccli init --remove
 ```
 
@@ -556,7 +556,7 @@ ccli init --remove
 
 #### Recommended Schema
 
-> **Deep dive:** See the [Schema Guide](docs/schema-guide.md) for the full rationale behind the file structure, what makes a good entry, and a walkthrough of the codexCLI project's own `.codexcli.json` as a reference implementation.
+> **Deep dive:** See the [Schema Guide](docs/schema-guide.md) for the full rationale behind the file structure, what makes a good entry, and a walkthrough of the codexCLI project's own `.codexcli/` as a reference implementation.
 
 When using CodexCLI as a project knowledge base (especially with AI agents via MCP), we recommend organizing entries under these namespaces:
 
@@ -592,7 +592,7 @@ Every AI session has the same problem: the agent starts from zero, spends thousa
 
 Here's how it works in practice:
 
-1. **You run `ccli init`** in a new project. The CLI scans the codebase in milliseconds and creates a skeleton `.codexcli.json` with project metadata, commands, file paths, dependencies, and conventions it can detect from the filesystem.
+1. **You run `ccli init`** in a new project. The CLI scans the codebase in milliseconds and creates a skeleton `.codexcli/` with project metadata, commands, file paths, dependencies, and conventions it can detect from the filesystem.
 
 2. **First AI session begins.** The agent calls `codex_context`, sees the skeleton, and recognizes it's a fresh project (`context.initialized: scaffold`). Before starting your task, it reads the actual source code — entry points, core modules, config files — and populates the deep knowledge: architecture decisions in `arch.*`, non-obvious gotchas in `context.*`, and rich file descriptions in `files.*`. This deep analysis runs once.
 
@@ -602,11 +602,11 @@ Here's how it works in practice:
 
 The knowledge base grows with every session. The token cost per session drops. `ccli stats` shows you the trend: bootstrap rate, hit rate, estimated tokens saved, per-namespace coverage. The more you use it, the more efficient every agent becomes.
 
-Because the knowledge lives in `.codexcli.json` (a plain JSON file committed to your repo), it works across machines, across team members, and across AI tools. No vendor lock-in, no cloud dependency, no API keys. Just a file that gets smarter over time.
+Because the knowledge lives in `.codexcli/` (plain JSON files committed to your repo), it works across machines, across team members, and across AI tools. No vendor lock-in, no cloud dependency, no API keys. Just files that get smarter over time.
 
 ### Data Management
 
-All data (entries, aliases, confirm metadata) is stored in a single `data.json` file — `~/.codexcli/data.json` for global data, `.codexcli.json` for project-scoped data.
+All data (entries, aliases, confirm metadata) is stored in a directory with one JSON file per entry plus `_aliases.json` and `_confirm.json` sidecars — `~/.codexcli/store/` for global data, `.codexcli/` for project-scoped data. Pre-v1.10.0 unified `.codexcli.json` / `data.json` files are automatically migrated on first access and the old file is renamed to `.backup`.
 
 ```bash
 # Export data to a timestamped file
@@ -723,7 +723,7 @@ ccli lint --json
 ccli lint -G
 ```
 
-Default namespaces: `project`, `commands`, `arch`, `conventions`, `context`, `files`, `deps`, `system`. Add custom namespaces in `.codexcli.json`:
+Default namespaces: `project`, `commands`, `arch`, `conventions`, `context`, `files`, `deps`, `system`. Add custom namespaces in `.codexcli/`:
 
 ```json
 {
@@ -832,7 +832,7 @@ ccli --debug get server.production
 | `info` | | | Show version, stats, and storage paths |
 | `alias` | | `<subcommand>` | Manage key aliases (set, remove, list, rename) |
 | `confirm` | | `<subcommand>` | Manage run confirmation (set, remove, list) |
-| `init` | | | Initialize project (`.codexcli.json` + codebase scan + `CLAUDE.md`) |
+| `init` | | | Initialize project (`.codexcli/` + codebase scan + `CLAUDE.md`) |
 | `stale` | | `[days]` | Show entries not updated in N days (default 30) |
 | `lint` | | | Check entries against namespace schema (`--json`) |
 | `stats` | | | View MCP usage telemetry and trends (`--period`, `--detailed`, `--json`) |
@@ -870,7 +870,7 @@ claude mcp add codexcli -- ccli mcp-server
 claude mcp add codexcli --scope project -- ccli mcp-server --cwd .
 ```
 
-The `--scope project` makes the registration per-project in Claude Code, and `--cwd .` tells the MCP server to use the project root for `.codexcli.json` detection. You can also use the `CODEX_PROJECT_DIR` environment variable instead of `--cwd`.
+The `--scope project` makes the registration per-project in Claude Code, and `--cwd .` tells the MCP server to use the project root for `.codexcli/` detection. You can also use the `CODEX_PROJECT_DIR` environment variable instead of `--cwd`.
 
 **npm global install** (`npm install -g .`) — dev mode:
 
@@ -951,7 +951,7 @@ claude mcp add codexcli -- node /absolute/path/to/dist/mcp-server.js
 | `codex_stats` | View usage telemetry and [token savings](docs/token-savings.md) (hit rate, exploration cost avoided, per-namespace breakdown, trends) |
 | `codex_audit` | Query the audit log of data mutations (before/after diffs, agent identity, scope, success/fail) |
 
-All data-touching tools accept an optional `scope` parameter (`"project"` or `"global"`). When listing entries (no key), `codex_get` defaults to project-only if a `.codexcli.json` exists — pass `all: true` to see both scopes. Single-key lookups fall through from project to global automatically.
+All data-touching tools accept an optional `scope` parameter (`"project"` or `"global"`). When listing entries (no key), `codex_get` defaults to project-only if a `.codexcli/` exists — pass `all: true` to see both scopes. Single-key lookups fall through from project to global automatically.
 
 ### LLM Instructions
 
@@ -989,7 +989,7 @@ A successful response will include `"serverInfo":{"name":"codexcli"}` in the JSO
 
 | Document | Description |
 |---|---|
-| [Schema Guide](docs/schema-guide.md) | How to structure `.codexcli.json` — namespaces, file anatomy, good vs bad entries, reference examples |
+| [Schema Guide](docs/schema-guide.md) | How to structure your `.codexcli/` store — namespaces, file anatomy, good vs bad entries, reference examples |
 | [Token Savings](docs/token-savings.md) | How CodexCLI measures AI agent efficiency — every metric explained, estimation methodology, limitations |
 | [Roadmap](docs/ROADMAP.md) | Completed features, upcoming milestones, long-term vision |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codexcli",
-	"version": "1.9.2",
+	"version": "1.10.0",
 	"description": "Persistent, structured knowledge store for software projects — CLI + MCP server for AI agent integration",
 	"bin": {
 		"cclid": "dist/index.js",

--- a/src/__tests__/cli-restructure.test.ts
+++ b/src/__tests__/cli-restructure.test.ts
@@ -6,8 +6,14 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { readDirectoryStore } from './helpers/readStoreState';
 
 let tmpDir: string;
+
+// v1.10.0: project store is a `.codexcli/` directory. Read via helper that
+// reconstitutes the legacy UnifiedData shape.
+const readProjectData = (dir: string) =>
+  readDirectoryStore(path.join(dir, '.codexcli'));
 const cliPath = path.resolve(__dirname, '..', '..', 'dist', 'index.js');
 
 const run = (args: string) => {
@@ -55,7 +61,7 @@ afterEach(() => {
 describe('alias subcommand', () => {
   it('alias set creates an alias', () => {
     run('alias set b commands.build');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.aliases.b).toBe('commands.build');
   });
 
@@ -69,14 +75,14 @@ describe('alias subcommand', () => {
   it('alias remove deletes an alias', () => {
     run('alias set b commands.build');
     run('alias remove b');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.aliases.b).toBeUndefined();
   });
 
   it('alias rename renames an alias', () => {
     run('alias set b commands.build');
     run('alias rename b bld');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.aliases.b).toBeUndefined();
     expect(data.aliases.bld).toBe('commands.build');
   });
@@ -92,7 +98,7 @@ describe('alias subcommand', () => {
 describe('confirm subcommand', () => {
   it('confirm set marks key as requiring confirmation', () => {
     run('confirm set commands.build');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.confirm['commands.build']).toBe(true);
   });
 
@@ -105,7 +111,7 @@ describe('confirm subcommand', () => {
   it('confirm remove removes confirmation', () => {
     run('confirm set commands.build');
     run('confirm remove commands.build');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.confirm['commands.build']).toBeUndefined();
   });
 
@@ -190,7 +196,7 @@ describe('deprecation notices', () => {
     });
     // The deprecation goes to stderr which we can't easily capture with execSync
     // but we can verify the alias was still created (backward compat works)
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir) as any;
     expect(data.aliases.dk).toBe('dep.key');
   });
 
@@ -201,7 +207,7 @@ describe('deprecation notices', () => {
     try {
       // --scaffold should still work but warn
       execSync(`node ${cliPath} init --scaffold --no-claude`, { cwd: freshDir, timeout: 10000 });
-      expect(fs.existsSync(path.join(freshDir, '.codexcli.json'))).toBe(true);
+      expect(fs.existsSync(path.join(freshDir, '.codexcli'))).toBe(true);
     } finally {
       fs.rmSync(freshDir, { recursive: true, force: true });
     }

--- a/src/__tests__/completions.test.ts
+++ b/src/__tests__/completions.test.ts
@@ -27,10 +27,45 @@ vi.mock('../utils/paths', () => ({
   getAliasFilePath: vi.fn(() => '/mock/aliases.json'),
   getConfirmFilePath: vi.fn(() => '/mock/confirm.json'),
   getConfigFilePath: vi.fn(() => '/mock/config.json'),
+  getGlobalStoreDirPath: vi.fn(() => '/mock/store'),
   ensureDataDirectoryExists: vi.fn(),
   findProjectFile: vi.fn(() => null),
+  findProjectStoreDir: vi.fn(() => null),
   clearProjectFileCache: vi.fn(),
 }));
+
+// v1.10.0: completions reads via loadData/loadAliases. Mock the facade
+// modules directly rather than trying to intercept fs calls made by the
+// file-per-entry store layer underneath.
+vi.mock('../storage', async () => {
+  const actual = await vi.importActual<typeof import('../storage')>('../storage');
+  return {
+    ...actual,
+    loadData: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('../alias', async () => {
+  const actual = await vi.importActual<typeof import('../alias')>('../alias');
+  return {
+    ...actual,
+    loadAliases: vi.fn(() => ({})),
+  };
+});
+
+import { loadData } from '../storage';
+import { loadAliases } from '../alias';
+import type { Mock } from 'vitest';
+
+/**
+ * Helper: set the data returned by the mocked store layer. Tests that
+ * previously did `(fs.readFileSync as Mock).mockReturnValue(JSON.stringify({entries, aliases}))`
+ * now do `setMockStore({entries, aliases})`.
+ */
+function setMockStore(state: { entries?: Record<string, unknown>; aliases?: Record<string, string> }): void {
+  (loadData as unknown as Mock).mockReturnValue(state.entries ?? {});
+  (loadAliases as unknown as Mock).mockReturnValue(state.aliases ?? {});
+}
 
 /** Extract just the .value strings from CompletionItem[] for simpler assertions */
 function values(items: CompletionItem[]): string[] {
@@ -339,11 +374,10 @@ describe('Completions', () => {
 
   describe('getDynamicValues via getCompletions', () => {
     it('returns data keys and alias names for dataKey commands', () => {
-      const mockData = { server: { ip: '1.2.3.4' } };
-      const mockAliases = { myip: 'server.ip' };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: mockAliases, confirm: {} })
-      );
+      setMockStore({
+        entries: { server: { ip: '1.2.3.4' } },
+        aliases: { myip: 'server.ip' },
+      });
 
       const results = getCompletions('ccli get ', 9);
       const v = values(results);
@@ -352,10 +386,7 @@ describe('Completions', () => {
     });
 
     it('returns data keys with "Entry" description', () => {
-      const mockData = { server: { ip: '1.2.3.4' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { server: { ip: '1.2.3.4' } } });
 
       const results = getCompletions('ccli get ', 9);
       const keyItem = findItem(results, 'server.ip');
@@ -364,10 +395,7 @@ describe('Completions', () => {
     });
 
     it('returns alias names with "Alias" description', () => {
-      const mockAliases = { myip: 'server.ip' };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: {}, aliases: mockAliases, confirm: {} })
-      );
+      setMockStore({ aliases: { myip: 'server.ip' } });
 
       const results = getCompletions('ccli get ', 9);
       const aliasItem = findItem(results, 'myip');
@@ -400,10 +428,7 @@ describe('Completions', () => {
 
   describe('dataKeyPrefix for set/s commands', () => {
     it('completes to namespace prefix instead of full key', () => {
-      const mockData = { test: { key1: 'val1', key2: 'val2' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { test: { key1: 'val1', key2: 'val2' } } });
 
       const results = getCompletions('ccli set te', 11);
       const v = values(results);
@@ -413,10 +438,7 @@ describe('Completions', () => {
     });
 
     it('shows leaf keys when partial includes the namespace dot', () => {
-      const mockData = { test: { key1: 'val1', key2: 'val2' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { test: { key1: 'val1', key2: 'val2' } } });
 
       const results = getCompletions('ccli set test.', 14);
       const v = values(results);
@@ -425,10 +447,9 @@ describe('Completions', () => {
     });
 
     it('deduplicates namespace prefixes', () => {
-      const mockData = { server: { prod: { ip: '1.2.3.4' }, dev: { ip: '5.6.7.8' } } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({
+        entries: { server: { prod: { ip: '1.2.3.4' }, dev: { ip: '5.6.7.8' } } },
+      });
 
       const results = getCompletions('ccli s ', 7);
       const v = values(results);
@@ -437,10 +458,9 @@ describe('Completions', () => {
     });
 
     it('completes nested namespace one level at a time', () => {
-      const mockData = { server: { prod: { ip: '1.2.3.4' }, dev: { ip: '5.6.7.8' } } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({
+        entries: { server: { prod: { ip: '1.2.3.4' }, dev: { ip: '5.6.7.8' } } },
+      });
 
       const results = getCompletions('ccli set server.', 16);
       const v = values(results);
@@ -450,10 +470,7 @@ describe('Completions', () => {
     });
 
     it('shows full key at leaf level', () => {
-      const mockData = { server: { prod: { ip: '1.2.3.4' } } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { server: { prod: { ip: '1.2.3.4' } } } });
 
       const results = getCompletions('ccli set server.prod.', 21);
       const v = values(results);
@@ -461,11 +478,10 @@ describe('Completions', () => {
     });
 
     it('includes aliases without truncation', () => {
-      const mockData = { test: { key1: 'val1' } };
-      const mockAliases = { myalias: 'test.key1' };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: mockAliases, confirm: {} })
-      );
+      setMockStore({
+        entries: { test: { key1: 'val1' } },
+        aliases: { myalias: 'test.key1' },
+      });
 
       const results = getCompletions('ccli set m', 10);
       const v = values(results);
@@ -473,10 +489,7 @@ describe('Completions', () => {
     });
 
     it('marks truncated values as Namespace', () => {
-      const mockData = { test: { key1: 'val1' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { test: { key1: 'val1' } } });
 
       const results = getCompletions('ccli set te', 11);
       const item = findItem(results, 'test.');
@@ -485,10 +498,7 @@ describe('Completions', () => {
     });
 
     it('does not affect get command (still returns full keys)', () => {
-      const mockData = { test: { key1: 'val1' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { test: { key1: 'val1' } } });
 
       const results = getCompletions('ccli get te', 11);
       const v = values(results);
@@ -497,10 +507,7 @@ describe('Completions', () => {
     });
 
     it('get command includes namespace prefixes (without dot)', () => {
-      const mockData = { test: { key1: 'val1', key2: 'val2' } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { test: { key1: 'val1', key2: 'val2' } } });
 
       const results = getCompletions('ccli get te', 11);
       const v = values(results);
@@ -512,10 +519,7 @@ describe('Completions', () => {
     });
 
     it('get includes nested namespace prefixes', () => {
-      const mockData = { server: { prod: { ip: '1.2.3.4' } } };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: { server: { prod: { ip: '1.2.3.4' } } } });
 
       const results = getCompletions('ccli g s', 8);
       const v = values(results);
@@ -527,11 +531,13 @@ describe('Completions', () => {
 
   describe('colon composition for run/r commands', () => {
     beforeEach(() => {
-      const mockData = { system: { commands: { cd: 'cd ' } }, paths: { home: '/Users/kh', github: '/Users/kh/Projects/github.com' } };
-      const mockAliases = { cd: 'system.commands.cd' };
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: mockData, aliases: mockAliases, confirm: {} })
-      );
+      setMockStore({
+        entries: {
+          system: { commands: { cd: 'cd ' } },
+          paths: { home: '/Users/kh', github: '/Users/kh/Projects/github.com' },
+        },
+        aliases: { cd: 'system.commands.cd' },
+      });
     });
 
     it('completes segment after : for run command', () => {
@@ -577,9 +583,7 @@ describe('Completions', () => {
 
   describe('getCompletions edge cases', () => {
     beforeEach(() => {
-      (fs.readFileSync as Mock).mockReturnValue(
-        JSON.stringify({ entries: {}, aliases: {}, confirm: {} })
-      );
+      setMockStore({ entries: {}, aliases: {} });
     });
 
     it('returns top-level commands for unknown command', () => {

--- a/src/__tests__/concurrency.test.ts
+++ b/src/__tests__/concurrency.test.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { execSync, fork } from 'child_process';
+import { readStoreState } from './helpers/readStoreState';
 
 let tmpDir: string;
 
@@ -203,11 +204,14 @@ for (let i = 0; i < 20; i++) {
   });
 
   it('stale lock is automatically broken', () => {
-    const dataPath = path.join(tmpDir, 'data.json');
-    fs.writeFileSync(dataPath, JSON.stringify({ entries: {}, aliases: {}, confirm: {} }));
+    // v1.10.0: seed the new store directory and use its sibling .lock path
+    const storeDir = path.join(tmpDir, 'store');
+    fs.mkdirSync(storeDir, { recursive: true });
+    fs.writeFileSync(path.join(storeDir, '_aliases.json'), '{}');
+    fs.writeFileSync(path.join(storeDir, '_confirm.json'), '{}');
 
-    // Create a "stale" lock (mtime 20s ago)
-    const lockPath = dataPath + '.lock';
+    // Create a "stale" lock (mtime 20s ago) at the sibling lock path
+    const lockPath = storeDir + '.lock';
     fs.writeFileSync(lockPath, '99999');
     const past = new Date(Date.now() - 20000);
     fs.utimesSync(lockPath, past, past);
@@ -222,15 +226,18 @@ for (let i = 0; i < 20; i++) {
     expect(fs.existsSync(lockPath)).toBe(false);
 
     // Data should be written
-    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const data = readStoreState(tmpDir) as any;
     expect(data.entries.stale?.lock?.test).toBe('it works');
   });
 });
 
 describe('concurrent CLI invocations', () => {
   it('parallel set commands all succeed', () => {
-    const dataPath = path.join(tmpDir, 'data.json');
-    fs.writeFileSync(dataPath, JSON.stringify({ entries: {}, aliases: {}, confirm: {} }));
+    // v1.10.0: seed the new store directory
+    const storeDir = path.join(tmpDir, 'store');
+    fs.mkdirSync(storeDir, { recursive: true });
+    fs.writeFileSync(path.join(storeDir, '_aliases.json'), '{}');
+    fs.writeFileSync(path.join(storeDir, '_confirm.json'), '{}');
 
     const COMMANDS = 8;
     const promises: Promise<string>[] = [];
@@ -266,7 +273,7 @@ describe('concurrent CLI invocations', () => {
     }
 
     // Verify all entries exist
-    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+    const data = readStoreState(tmpDir) as any;
     for (let i = 0; i < COMMANDS; i++) {
       expect(data.entries.parallel[`key${i}`]).toBe(`value${i}`);
     }

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -1,0 +1,475 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  createDirectoryStore,
+  migrateFileToDirectory,
+  parseEntryWrapper,
+  serializeEntryWrapper,
+  entryFilePath,
+  getStoreLockPath,
+  type EntryWrapper,
+} from '../utils/directoryStore';
+import type { UnifiedData } from '../store';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-dirstore-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeStore(dir: string) {
+  return createDirectoryStore(
+    () => dir,
+    () => {
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+  );
+}
+
+function readJson<T = unknown>(p: string): T {
+  return JSON.parse(fs.readFileSync(p, 'utf8')) as T;
+}
+
+// ── createDirectoryStore: load ─────────────────────────────────────────
+
+describe('createDirectoryStore.load', () => {
+  it('returns empty UnifiedData when directory does not exist', () => {
+    const store = makeStore(path.join(tmpRoot, 'nope'));
+    const data = store.load();
+    expect(data).toEqual({ entries: {}, aliases: {}, confirm: {} });
+  });
+
+  it('returns empty UnifiedData for an empty directory', () => {
+    const dir = path.join(tmpRoot, 'empty');
+    fs.mkdirSync(dir);
+    const store = makeStore(dir);
+    const data = store.load();
+    expect(data).toEqual({ entries: {}, aliases: {}, confirm: {} });
+  });
+
+  it('reads entry files and reconstructs nested entries', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, 'arch.storage.json'),
+      JSON.stringify({ value: 'unified data.json', meta: { updated: 1000, created: 1000 } })
+    );
+    fs.writeFileSync(
+      path.join(dir, 'arch.scope.json'),
+      JSON.stringify({ value: 'three scopes', meta: { updated: 2000, created: 2000 } })
+    );
+    fs.writeFileSync(
+      path.join(dir, 'commands.test.json'),
+      JSON.stringify({ value: 'npm test' })
+    );
+
+    const store = makeStore(dir);
+    const data = store.load();
+
+    expect(data.entries).toEqual({
+      arch: { storage: 'unified data.json', scope: 'three scopes' },
+      commands: { test: 'npm test' },
+    });
+    expect(data._meta).toEqual({
+      'arch.storage': 1000,
+      'arch.scope': 2000,
+      // commands.test is untracked — not in _meta
+    });
+  });
+
+  it('reads sidecars for aliases and confirm', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, '_aliases.json'), JSON.stringify({ rel: 'commands.release' }));
+    fs.writeFileSync(path.join(dir, '_confirm.json'), JSON.stringify({ 'commands.release': true }));
+
+    const store = makeStore(dir);
+    const data = store.load();
+
+    expect(data.aliases).toEqual({ rel: 'commands.release' });
+    expect(data.confirm).toEqual({ 'commands.release': true });
+  });
+
+  it('skips unparseable entry files without crashing', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'good.json'), JSON.stringify({ value: 'ok' }));
+    fs.writeFileSync(path.join(dir, 'bad.json'), 'not json');
+    fs.writeFileSync(path.join(dir, 'also.bad.json'), JSON.stringify({ not: 'a wrapper' }));
+
+    const store = makeStore(dir);
+    const data = store.load();
+
+    expect(data.entries).toEqual({ good: 'ok' });
+  });
+
+  it('ignores files without .json extension and underscore-prefixed files', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'entry.json'), JSON.stringify({ value: 'v' }));
+    fs.writeFileSync(path.join(dir, 'README.md'), '# notes');
+    fs.writeFileSync(path.join(dir, '_aliases.json'), JSON.stringify({ a: 'b' }));
+
+    const store = makeStore(dir);
+    const data = store.load();
+
+    expect(Object.keys(data.entries)).toEqual(['entry']);
+  });
+});
+
+// ── createDirectoryStore: save ─────────────────────────────────────────
+
+describe('createDirectoryStore.save', () => {
+  it('writes per-entry files and sidecars on first save', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    const data: UnifiedData = {
+      entries: { arch: { storage: 'one', scope: 'two' } },
+      aliases: { s: 'arch.storage' },
+      confirm: { 'arch.storage': true },
+      _meta: { 'arch.storage': 1000, 'arch.scope': 2000 },
+    };
+    store.save(data);
+
+    expect(fs.existsSync(path.join(dir, 'arch.storage.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'arch.scope.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, '_aliases.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, '_confirm.json'))).toBe(true);
+
+    const storageWrapper = readJson<EntryWrapper>(path.join(dir, 'arch.storage.json'));
+    expect(storageWrapper.value).toBe('one');
+    expect(storageWrapper.meta).toEqual({ created: 1000, updated: 1000 });
+  });
+
+  it('round-trips cleanly: save then load returns equivalent data', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    const data: UnifiedData = {
+      entries: { foo: { bar: 'baz', qux: 'quux' }, top: 'level' },
+      aliases: { b: 'foo.bar' },
+      confirm: {},
+      _meta: { 'foo.bar': 500, 'foo.qux': 600, top: 700 },
+    };
+    store.save(data);
+
+    // Fresh store (no shared cache) to verify disk state is the source of truth
+    const fresh = makeStore(dir);
+    const loaded = fresh.load();
+
+    expect(loaded.entries).toEqual(data.entries);
+    expect(loaded.aliases).toEqual(data.aliases);
+    expect(loaded.confirm).toEqual(data.confirm);
+    expect(loaded._meta).toEqual(data._meta);
+  });
+
+  it('preserves created on subsequent saves, bumps updated', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({
+      entries: { foo: 'v1' },
+      aliases: {},
+      confirm: {},
+      _meta: { foo: 100 },
+    });
+
+    store.save({
+      entries: { foo: 'v2' },
+      aliases: {},
+      confirm: {},
+      _meta: { foo: 200 },
+    });
+
+    const wrapper = readJson<EntryWrapper>(path.join(dir, 'foo.json'));
+    expect(wrapper.value).toBe('v2');
+    expect(wrapper.meta).toEqual({ created: 100, updated: 200 });
+  });
+
+  it('dirty tracking: unchanged files are not rewritten', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({
+      entries: { a: '1', b: '2', c: '3' },
+      aliases: {},
+      confirm: {},
+      _meta: { a: 100, b: 200, c: 300 },
+    });
+
+    const beforeMtimes = {
+      a: fs.statSync(path.join(dir, 'a.json')).mtimeMs,
+      b: fs.statSync(path.join(dir, 'b.json')).mtimeMs,
+      c: fs.statSync(path.join(dir, 'c.json')).mtimeMs,
+    };
+
+    // Wait long enough for any in-place write to bump mtime
+    const target = Date.now() + 20;
+    while (Date.now() < target) { /* spin */ }
+
+    // Save with only `b` changed (new value and new timestamp)
+    store.save({
+      entries: { a: '1', b: 'changed', c: '3' },
+      aliases: {},
+      confirm: {},
+      _meta: { a: 100, b: 999, c: 300 },
+    });
+
+    const afterMtimes = {
+      a: fs.statSync(path.join(dir, 'a.json')).mtimeMs,
+      b: fs.statSync(path.join(dir, 'b.json')).mtimeMs,
+      c: fs.statSync(path.join(dir, 'c.json')).mtimeMs,
+    };
+
+    expect(afterMtimes.a).toBe(beforeMtimes.a);  // unchanged
+    expect(afterMtimes.c).toBe(beforeMtimes.c);  // unchanged
+    expect(afterMtimes.b).toBeGreaterThan(beforeMtimes.b);  // rewritten
+  });
+
+  it('removes entry files for keys that disappear from the new state', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({
+      entries: { a: '1', b: '2' },
+      aliases: {},
+      confirm: {},
+      _meta: { a: 100, b: 200 },
+    });
+
+    store.save({
+      entries: { a: '1' },  // b removed
+      aliases: {},
+      confirm: {},
+      _meta: { a: 100 },
+    });
+
+    expect(fs.existsSync(path.join(dir, 'a.json'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'b.json'))).toBe(false);
+  });
+
+  it('empty entries {} removes all entry files but keeps sidecars', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({
+      entries: { a: '1', b: '2' },
+      aliases: { x: 'a' },
+      confirm: {},
+      _meta: { a: 100, b: 200 },
+    });
+
+    store.save({
+      entries: {},
+      aliases: { x: 'a' },
+      confirm: {},
+    });
+
+    expect(fs.existsSync(path.join(dir, 'a.json'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, 'b.json'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, '_aliases.json'))).toBe(true);
+  });
+
+  it('untracked entries (no _meta timestamp) are written without a meta block', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({
+      entries: { untracked: 'value' },
+      aliases: {},
+      confirm: {},
+    });
+
+    const wrapper = readJson<EntryWrapper>(path.join(dir, 'untracked.json'));
+    expect(wrapper.value).toBe('value');
+    expect(wrapper.meta).toBeUndefined();
+  });
+});
+
+// ── migrateFileToDirectory ─────────────────────────────────────────────
+
+describe('migrateFileToDirectory', () => {
+  it('is a no-op when neither old file nor new dir exists', () => {
+    const result = migrateFileToDirectory(
+      path.join(tmpRoot, 'nothing.json'),
+      path.join(tmpRoot, 'nothing')
+    );
+    expect(result.status).toBe('no-op');
+    expect(fs.existsSync(path.join(tmpRoot, 'nothing'))).toBe(false);
+  });
+
+  it('returns already-present when new directory exists', () => {
+    const oldFile = path.join(tmpRoot, 'data.json');
+    const newDir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(newDir);
+    // No old file, but new dir exists → already-present, no-op
+    const result = migrateFileToDirectory(oldFile, newDir);
+    expect(result.status).toBe('already-present');
+  });
+
+  it('cleans up lingering old file when new directory already exists', () => {
+    const oldFile = path.join(tmpRoot, 'data.json');
+    const newDir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(newDir);
+    fs.writeFileSync(oldFile, '{"entries":{"stale":"value"}}');
+
+    const result = migrateFileToDirectory(oldFile, newDir);
+
+    expect(result.status).toBe('already-present');
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(oldFile + '.backup')).toBe(true);
+  });
+
+  it('migrates a unified file to per-entry wrappers', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: {
+        arch: { storage: 'unified', scope: 'three' },
+        commands: { test: 'npm test' },
+      },
+      aliases: { t: 'commands.test' },
+      confirm: { 'commands.test': true },
+      _meta: { 'arch.storage': 1000, 'arch.scope': 2000, 'commands.test': 3000 },
+    }));
+
+    const result = migrateFileToDirectory(oldFile, newDir);
+
+    expect(result.status).toBe('migrated');
+    expect(result.entryCount).toBe(3);
+    expect(result.backupPath).toBe(oldFile + '.backup');
+
+    // Old file gone, backup exists
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(oldFile + '.backup')).toBe(true);
+
+    // Entry files written with wrappers
+    const storageWrapper = readJson<EntryWrapper>(path.join(newDir, 'arch.storage.json'));
+    expect(storageWrapper.value).toBe('unified');
+    expect(storageWrapper.meta).toEqual({ created: 1000, updated: 1000 });
+
+    const testWrapper = readJson<EntryWrapper>(path.join(newDir, 'commands.test.json'));
+    expect(testWrapper.value).toBe('npm test');
+    expect(testWrapper.meta).toEqual({ created: 3000, updated: 3000 });
+
+    // Sidecars written
+    expect(readJson(path.join(newDir, '_aliases.json'))).toEqual({ t: 'commands.test' });
+    expect(readJson(path.join(newDir, '_confirm.json'))).toEqual({ 'commands.test': true });
+  });
+
+  it('preserves untracked entries (missing from _meta) as bare wrappers', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: { tracked: 'a', untracked: 'b' },
+      aliases: {},
+      confirm: {},
+      _meta: { tracked: 1000 },  // only `tracked` has a timestamp
+    }));
+
+    migrateFileToDirectory(oldFile, newDir);
+
+    const trackedWrapper = readJson<EntryWrapper>(path.join(newDir, 'tracked.json'));
+    expect(trackedWrapper.meta).toEqual({ created: 1000, updated: 1000 });
+
+    const untrackedWrapper = readJson<EntryWrapper>(path.join(newDir, 'untracked.json'));
+    expect(untrackedWrapper.value).toBe('b');
+    expect(untrackedWrapper.meta).toBeUndefined();
+  });
+
+  it('migrates a file with empty entries/aliases/confirm', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({ entries: {}, aliases: {}, confirm: {} }));
+
+    const result = migrateFileToDirectory(oldFile, newDir);
+
+    expect(result.status).toBe('migrated');
+    expect(result.entryCount).toBe(0);
+    expect(fs.existsSync(path.join(newDir, '_aliases.json'))).toBe(true);
+    expect(fs.existsSync(path.join(newDir, '_confirm.json'))).toBe(true);
+  });
+
+  it('throws a helpful error on corrupt JSON in the old file', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, '{not json');
+
+    expect(() => migrateFileToDirectory(oldFile, newDir)).toThrow(/Failed to parse/);
+    // New dir should not exist after a failed migration
+    expect(fs.existsSync(newDir)).toBe(false);
+  });
+
+  it('overwrites a pre-existing .backup if another migration was interrupted', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({ entries: { a: '1' }, aliases: {}, confirm: {} }));
+    fs.writeFileSync(oldFile + '.backup', 'stale backup from aborted migration');
+
+    const result = migrateFileToDirectory(oldFile, newDir);
+
+    expect(result.status).toBe('migrated');
+    // The backup should now reflect the freshly-migrated old file, not the stale text
+    const backupContent = fs.readFileSync(oldFile + '.backup', 'utf8');
+    expect(backupContent).toContain('"entries"');
+  });
+});
+
+// ── Helper functions ───────────────────────────────────────────────────
+
+describe('parseEntryWrapper', () => {
+  it('parses a minimal wrapper', () => {
+    expect(parseEntryWrapper('{"value":"hello"}')).toEqual({ value: 'hello' });
+  });
+
+  it('parses a wrapper with meta', () => {
+    const raw = '{"value":"hi","meta":{"created":1,"updated":2}}';
+    expect(parseEntryWrapper(raw)).toEqual({
+      value: 'hi',
+      meta: { created: 1, updated: 2 },
+    });
+  });
+
+  it('returns null for missing value field', () => {
+    expect(parseEntryWrapper('{"other":"thing"}')).toBeNull();
+  });
+
+  it('returns null for invalid JSON', () => {
+    expect(parseEntryWrapper('{not json')).toBeNull();
+  });
+
+  it('parses a nested-object value', () => {
+    const raw = '{"value":{"nested":"string"}}';
+    expect(parseEntryWrapper(raw)).toEqual({ value: { nested: 'string' } });
+  });
+});
+
+describe('serializeEntryWrapper', () => {
+  it('produces pretty-printed JSON', () => {
+    const out = serializeEntryWrapper({ value: 'hi', meta: { updated: 100 } });
+    expect(out).toContain('\n');  // pretty-printed
+    expect(JSON.parse(out)).toEqual({ value: 'hi', meta: { updated: 100 } });
+  });
+
+  it('omits meta when not provided', () => {
+    const out = serializeEntryWrapper({ value: 'hi' });
+    expect(JSON.parse(out)).toEqual({ value: 'hi' });
+  });
+});
+
+describe('entryFilePath', () => {
+  it('appends .json to the key within the directory', () => {
+    expect(entryFilePath('/store', 'arch.storage')).toBe(path.join('/store', 'arch.storage.json'));
+  });
+});
+
+describe('getStoreLockPath', () => {
+  it('returns a sibling .lock path', () => {
+    expect(getStoreLockPath('/a/b/.codexcli')).toBe('/a/b/.codexcli.lock');
+  });
+});

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -7,7 +7,7 @@ import {
   parseEntryWrapper,
   serializeEntryWrapper,
   entryFilePath,
-  getStoreLockPath,
+  getStoreLockKey,
   type EntryWrapper,
 } from '../utils/directoryStore';
 import type { UnifiedData } from '../store';
@@ -468,8 +468,8 @@ describe('entryFilePath', () => {
   });
 });
 
-describe('getStoreLockPath', () => {
-  it('returns a sibling .lock path', () => {
-    expect(getStoreLockPath('/a/b/.codexcli')).toBe('/a/b/.codexcli.lock');
+describe('getStoreLockKey', () => {
+  it('returns the directory path unchanged (withFileLock appends .lock)', () => {
+    expect(getStoreLockKey('/a/b/.codexcli')).toBe('/a/b/.codexcli');
   });
 });

--- a/src/__tests__/entries-advanced.test.ts
+++ b/src/__tests__/entries-advanced.test.ts
@@ -8,6 +8,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { readStoreState } from './helpers/readStoreState';
 
 let tmpDir: string;
 
@@ -18,14 +19,18 @@ const run = (args: string) => {
   }).toString();
 };
 
-const readData = () => JSON.parse(fs.readFileSync(path.join(tmpDir, 'data.json'), 'utf8'));
+// v1.10.0: reads the file-per-entry store directory and reconstitutes the
+// legacy UnifiedData shape the tests assert against. Falls back to reading
+// a pre-migration data.json if the store dir doesn't exist yet.
+const readData = () => readStoreState(tmpDir);
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-entries-'));
-  fs.writeFileSync(
-    path.join(tmpDir, 'data.json'),
-    JSON.stringify({ entries: {}, aliases: {}, confirm: {} })
-  );
+  // Seed an empty store directory directly — equivalent to the old practice
+  // of writing an empty data.json, but in the v1.10.0 layout.
+  fs.mkdirSync(path.join(tmpDir, 'store'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'store', '_aliases.json'), '{}');
+  fs.writeFileSync(path.join(tmpDir, 'store', '_confirm.json'), '{}');
 });
 
 afterEach(() => {

--- a/src/__tests__/helpers/readStoreState.ts
+++ b/src/__tests__/helpers/readStoreState.ts
@@ -89,12 +89,22 @@ function setNested(obj: Record<string, unknown>, key: string, value: unknown): v
   let current = obj;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];
-    if (current[part] === undefined || typeof current[part] !== 'object') {
-      current[part] = {};
+    // Guard against prototype pollution via well-known dangerous property names.
+    if (part === '__proto__' || part === 'constructor' || part === 'prototype') return;
+    const next = current[part];
+    if (next === null || next === undefined || typeof next !== 'object') {
+      // Use Object.create(null) so intermediate objects have no prototype to pollute.
+      const fresh = Object.create(null) as Record<string, unknown>;
+      current[part] = fresh;
+      current = fresh;
+    } else {
+      current = next as Record<string, unknown>;
     }
-    current = current[part] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  const lastPart = parts[parts.length - 1];
+  if (lastPart !== '__proto__' && lastPart !== 'constructor' && lastPart !== 'prototype') {
+    current[lastPart] = value;
+  }
 }
 
 /**

--- a/src/__tests__/helpers/readStoreState.ts
+++ b/src/__tests__/helpers/readStoreState.ts
@@ -1,0 +1,141 @@
+/**
+ * Test helper that reads a v1.10.0 file-per-entry store directory and
+ * reconstitutes the legacy UnifiedData shape (`{entries, aliases, confirm, _meta}`)
+ * that most existing tests assert against. Lets tests migrate to the new
+ * layout without rewriting every assertion.
+ *
+ * Falls back to reading a pre-migration `data.json` in the same parent directory
+ * if the store directory doesn't exist yet, so tests that set up the old format
+ * and trigger migration via the store API can still read the pre-migration state.
+ */
+import fs from 'fs';
+import path from 'path';
+
+export interface ReconstitutedStoreState {
+  entries: Record<string, unknown>;
+  aliases: Record<string, unknown>;
+  confirm: Record<string, unknown>;
+  _meta?: Record<string, number>;
+}
+
+/**
+ * Read a store directory (containing entry wrappers and sidecars) and
+ * reconstruct the UnifiedData shape. If the directory doesn't exist, fall
+ * back to reading `<dataDir>/data.json` (the legacy pre-migration file).
+ *
+ * @param dataDir  The parent directory containing either `store/` (new) or
+ *                 `data.json` (legacy). For project stores, pass the path to
+ *                 the `.codexcli/` directory directly as `storeDir` instead.
+ * @param storeDir Optional absolute path to the store directory. If omitted,
+ *                 defaults to `path.join(dataDir, 'store')`.
+ */
+export function readStoreState(dataDir: string, storeDir?: string): ReconstitutedStoreState {
+  const resolvedStoreDir = storeDir ?? path.join(dataDir, 'store');
+
+  if (fs.existsSync(resolvedStoreDir) && fs.statSync(resolvedStoreDir).isDirectory()) {
+    return readDirectoryStore(resolvedStoreDir);
+  }
+
+  // Pre-migration fallback
+  const legacyPath = path.join(dataDir, 'data.json');
+  if (fs.existsSync(legacyPath)) {
+    return JSON.parse(fs.readFileSync(legacyPath, 'utf8')) as ReconstitutedStoreState;
+  }
+
+  return { entries: {}, aliases: {}, confirm: {} };
+}
+
+/**
+ * Read a store directory (or a project `.codexcli/` directory) and reconstruct
+ * the UnifiedData shape.
+ */
+export function readDirectoryStore(storeDir: string): ReconstitutedStoreState {
+  const entries: Record<string, unknown> = {};
+  const meta: Record<string, number> = {};
+  let aliases: Record<string, unknown> = {};
+  let confirm: Record<string, unknown> = {};
+
+  const files = fs.readdirSync(storeDir);
+  for (const file of files) {
+    const filePath = path.join(storeDir, file);
+    if (file === '_aliases.json') {
+      aliases = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+      continue;
+    }
+    if (file === '_confirm.json') {
+      confirm = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+      continue;
+    }
+    if (file.endsWith('.json') && !file.startsWith('_')) {
+      const key = file.slice(0, -'.json'.length);
+      const wrapper = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+        value: unknown;
+        meta?: { updated?: number; created?: number };
+      };
+      setNested(entries, key, wrapper.value);
+      if (wrapper.meta?.updated !== undefined) {
+        meta[key] = wrapper.meta.updated;
+      }
+    }
+  }
+
+  const result: ReconstitutedStoreState = { entries, aliases, confirm };
+  if (Object.keys(meta).length > 0) result._meta = meta;
+  return result;
+}
+
+function setNested(obj: Record<string, unknown>, key: string, value: unknown): void {
+  const parts = key.split('.');
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (current[part] === undefined || typeof current[part] !== 'object') {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+/**
+ * Write a legacy UnifiedData-shaped object to a directory as the new
+ * file-per-entry layout. Useful for tests that want to seed the store
+ * in the new format directly instead of writing the old `data.json`
+ * and relying on migration.
+ */
+export function writeDirectoryStore(
+  storeDir: string,
+  state: { entries?: Record<string, unknown>; aliases?: Record<string, unknown>; confirm?: Record<string, unknown>; _meta?: Record<string, number> }
+): void {
+  if (!fs.existsSync(storeDir)) {
+    fs.mkdirSync(storeDir, { recursive: true });
+  }
+
+  const flat = flattenNested(state.entries ?? {});
+  for (const [key, value] of Object.entries(flat)) {
+    const updated = state._meta?.[key];
+    const wrapper = updated !== undefined
+      ? { value, meta: { created: updated, updated } }
+      : { value };
+    fs.writeFileSync(path.join(storeDir, `${key}.json`), JSON.stringify(wrapper, null, 2));
+  }
+
+  fs.writeFileSync(path.join(storeDir, '_aliases.json'), JSON.stringify(state.aliases ?? {}, null, 2));
+  fs.writeFileSync(path.join(storeDir, '_confirm.json'), JSON.stringify(state.confirm ?? {}, null, 2));
+}
+
+function flattenNested(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(out, flattenNested(value as Record<string, unknown>, fullKey));
+    } else {
+      out[fullKey] = value;
+    }
+  }
+  return out;
+}

--- a/src/__tests__/info.test.ts
+++ b/src/__tests__/info.test.ts
@@ -35,6 +35,7 @@ vi.mock('../store', () => ({
 vi.mock('../utils/paths', () => ({
   getUnifiedDataFilePath: vi.fn(() => '/mock/data.json'),
   getConfigFilePath: vi.fn(() => '/mock/config.json'),
+  getGlobalStoreDirPath: vi.fn(() => '/mock/store'),
 }));
 
 vi.mock('fs', () => {
@@ -82,7 +83,7 @@ describe('showInfo', () => {
   it('shows storage paths', () => {
     showInfo();
     const output = getOutput();
-    expect(output).toContain('data.json');
+    expect(output).toContain('/mock/store');
     expect(output).toContain('config.json');
   });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -5,8 +5,16 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { readDirectoryStore } from './helpers/readStoreState';
 
 let tmpDir: string;
+
+// v1.10.0: `ccli init` creates a `.codexcli/` directory, not a `.codexcli.json`
+// file. These helpers read the new layout and reconstitute the legacy shape.
+const readProjectData = (dir: string) =>
+  readDirectoryStore(path.join(dir, '.codexcli'));
+
+const projectStorePath = (dir: string) => path.join(dir, '.codexcli');
 
 // Resolve the CLI path relative to the project root (two levels up from __tests__)
 const cliPath = path.resolve(__dirname, '..', '..', 'dist', 'index.js');
@@ -40,16 +48,16 @@ afterEach(() => {
 });
 
 describe('ccli init — full flow', () => {
-  it('creates .codexcli.json with scanned entries', () => {
+  it('creates .codexcli/ with scanned entries', () => {
     const output = run('init');
     expect(output).toContain('Created:');
 
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
-    expect(data.entries.project.name).toBe('init-test');
-    expect(data.entries.project.stack).toContain('Node.js');
-    expect(data.entries.commands.build).toBe('npm run build');
-    expect(data.entries.files.entry).toContain('src/index.ts');
-    expect(data.entries.conventions.types).toContain('strict');
+    const data = readProjectData(tmpDir);
+    expect((data.entries as any).project.name).toBe('init-test');
+    expect((data.entries as any).project.stack).toContain('Node.js');
+    expect((data.entries as any).commands.build).toBe('npm run build');
+    expect((data.entries as any).files.entry).toContain('src/index.ts');
+    expect((data.entries as any).conventions.types).toContain('strict');
   });
 
   it('creates CLAUDE.md', () => {
@@ -62,17 +70,18 @@ describe('ccli init — full flow', () => {
 
   it('seeds conventions.persistence', () => {
     run('init');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
-    expect(data.entries.conventions.persistence).toContain('.codexcli.json');
-    expect(data.entries.conventions.persistence).toContain('CLAUDE.md');
-    expect(data.entries.conventions.persistence).toContain('MEMORY.md');
+    const data = readProjectData(tmpDir);
+    const persistence = (data.entries as any).conventions.persistence;
+    expect(persistence).toContain('.codexcli');
+    expect(persistence).toContain('CLAUDE.md');
+    expect(persistence).toContain('MEMORY.md');
   });
 
   it('detects deps from package.json', () => {
     run('init');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
-    expect(data.entries.deps.express).toContain('Express');
-    expect(data.entries.deps.vitest).toContain('Vitest');
+    const data = readProjectData(tmpDir);
+    expect((data.entries as any).deps.express).toContain('Express');
+    expect((data.entries as any).deps.vitest).toContain('Vitest');
   });
 });
 
@@ -80,37 +89,35 @@ describe('ccli init — idempotency', () => {
   it('running twice produces no duplicates', () => {
     run('init');
     const output2 = run('init');
-    // Second run: .codexcli.json exists, entries exist, CLAUDE.md exists
+    // Second run: .codexcli/ exists, entries exist, CLAUDE.md exists
     expect(output2).toContain('already exists');
   });
 
   it('second run does not modify existing entries', () => {
     run('init');
-    const first = fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8');
+    const first = readProjectData(tmpDir);
 
     run('init');
-    const second = fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8');
+    const second = readProjectData(tmpDir);
 
-    // Parse and compare entries (ignoring _meta timestamps)
-    const firstData = JSON.parse(first);
-    const secondData = JSON.parse(second);
-    delete firstData._meta;
-    delete secondData._meta;
-    expect(secondData).toEqual(firstData);
+    // Compare entries (ignoring _meta timestamps)
+    delete first._meta;
+    delete second._meta;
+    expect(second).toEqual(first);
   });
 });
 
 describe('ccli init — flags', () => {
   it('--no-scan skips codebase analysis', () => {
     run('init --no-scan');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
+    const data = readProjectData(tmpDir);
     // Entries should be empty (no scan)
     expect(data.entries).toEqual({});
   });
 
   it('--no-claude skips CLAUDE.md generation', () => {
     run('init --no-claude');
-    expect(fs.existsSync(path.join(tmpDir, '.codexcli.json'))).toBe(true);
+    expect(fs.existsSync(projectStorePath(tmpDir))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
   });
 
@@ -122,35 +129,35 @@ describe('ccli init — flags', () => {
     expect(claudeMd).not.toContain('custom content');
   });
 
-  it('--remove deletes .codexcli.json', () => {
+  it('--remove deletes .codexcli/', () => {
     run('init'); // create it first
-    expect(fs.existsSync(path.join(tmpDir, '.codexcli.json'))).toBe(true);
+    expect(fs.existsSync(projectStorePath(tmpDir))).toBe(true);
 
     run('init --remove');
-    expect(fs.existsSync(path.join(tmpDir, '.codexcli.json'))).toBe(false);
+    expect(fs.existsSync(projectStorePath(tmpDir))).toBe(false);
   });
 
   it('--scaffold still works (backward compat)', () => {
     run('init --scaffold');
-    const data = JSON.parse(fs.readFileSync(path.join(tmpDir, '.codexcli.json'), 'utf8'));
-    expect(data.entries.project.name).toBe('init-test');
+    const data = readProjectData(tmpDir);
+    expect((data.entries as any).project.name).toBe('init-test');
   });
 
   it('--dry-run previews without writing', () => {
     const output = run('init --dry-run');
     expect(output).toContain('Would scaffold');
     // Files should NOT be created
-    expect(fs.existsSync(path.join(tmpDir, '.codexcli.json'))).toBe(false);
+    expect(fs.existsSync(projectStorePath(tmpDir))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
   });
 });
 
 describe('ccli init — empty directory', () => {
-  it('creates .codexcli.json and CLAUDE.md even with no project files', () => {
+  it('creates .codexcli/ and CLAUDE.md even with no project files', () => {
     const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-init-empty-'));
     try {
       run('init', emptyDir);
-      expect(fs.existsSync(path.join(emptyDir, '.codexcli.json'))).toBe(true);
+      expect(fs.existsSync(projectStorePath(emptyDir))).toBe(true);
       expect(fs.existsSync(path.join(emptyDir, 'CLAUDE.md'))).toBe(true);
     } finally {
       fs.rmSync(emptyDir, { recursive: true, force: true });

--- a/src/__tests__/mcp-advanced.test.ts
+++ b/src/__tests__/mcp-advanced.test.ts
@@ -170,7 +170,9 @@ vi.mock('../utils/paths', () => ({
   getConfirmFilePath: vi.fn(() => '/mock/confirm.json'),
   getUnifiedDataFilePath: vi.fn(() => '/mock/data.json'),
   getDataDirectory: vi.fn(() => '/mock'),
+  getGlobalStoreDirPath: vi.fn(() => '/mock/store'),
   findProjectFile: vi.fn(() => null),
+  findProjectStoreDir: vi.fn(() => null),
   clearProjectFileCache: vi.fn(),
 }));
 

--- a/src/__tests__/mcp-integration.test.ts
+++ b/src/__tests__/mcp-integration.test.ts
@@ -9,15 +9,16 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { readStoreState, writeDirectoryStore } from './helpers/readStoreState';
 
 let tmpDir: string;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-mcp-integ-'));
-  fs.writeFileSync(
-    path.join(tmpDir, 'data.json'),
-    JSON.stringify({ entries: {}, aliases: {}, confirm: {} })
-  );
+  // v1.10.0: seed an empty store directory directly
+  fs.mkdirSync(path.join(tmpDir, 'store'), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, 'store', '_aliases.json'), '{}');
+  fs.writeFileSync(path.join(tmpDir, 'store', '_confirm.json'), '{}');
 });
 
 afterEach(() => {
@@ -93,7 +94,9 @@ function callMcpTool(tool: string, params: Record<string, unknown> = {}): { cont
 }
 
 function readDataFile(): Record<string, unknown> {
-  return JSON.parse(fs.readFileSync(path.join(tmpDir, 'data.json'), 'utf8'));
+  // v1.10.0: reads the file-per-entry store directory and reconstitutes
+  // the legacy UnifiedData shape the tests assert against.
+  return readStoreState(tmpDir) as Record<string, unknown>;
 }
 
 describe('MCP Integration (real I/O)', () => {
@@ -188,12 +191,12 @@ describe('MCP Integration (real I/O)', () => {
     });
 
     it('lists aliases from disk', () => {
-      // Pre-populate data file with an alias
-      const dataPath = path.join(tmpDir, 'data.json');
-      const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-      data.entries.commands = { test: 'npm test' };
-      data.aliases = { tst: 'commands.test' };
-      fs.writeFileSync(dataPath, JSON.stringify(data));
+      // Pre-populate store directory with an alias (v1.10.0 format)
+      writeDirectoryStore(path.join(tmpDir, 'store'), {
+        entries: { commands: { test: 'npm test' } },
+        aliases: { tst: 'commands.test' },
+        confirm: {},
+      });
 
       const listResult = callMcpTool('codex_alias_list', {});
       expect(listResult.content[0].text).toContain('tst');
@@ -201,12 +204,12 @@ describe('MCP Integration (real I/O)', () => {
     });
 
     it('removes alias from disk', () => {
-      // Pre-populate
-      const dataPath = path.join(tmpDir, 'data.json');
-      const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-      data.entries.x = { y: 'val' };
-      data.aliases = { xy: 'x.y' };
-      fs.writeFileSync(dataPath, JSON.stringify(data));
+      // Pre-populate store directory (v1.10.0 format)
+      writeDirectoryStore(path.join(tmpDir, 'store'), {
+        entries: { x: { y: 'val' } },
+        aliases: { xy: 'x.y' },
+        confirm: {},
+      });
 
       callMcpTool('codex_alias_remove', { alias: 'xy' });
 

--- a/src/__tests__/mcp-server.test.ts
+++ b/src/__tests__/mcp-server.test.ts
@@ -174,7 +174,9 @@ vi.mock('../utils/paths', () => ({
   getConfirmFilePath: vi.fn(() => '/mock/confirm.json'),
   getUnifiedDataFilePath: vi.fn(() => '/mock/data.json'),
   getDataDirectory: vi.fn(() => '/mock'),
+  getGlobalStoreDirPath: vi.fn(() => '/mock/store'),
   findProjectFile: vi.fn(() => null),
+  findProjectStoreDir: vi.fn(() => null),
   clearProjectFileCache: vi.fn(),
 }));
 

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -207,5 +207,106 @@ describe('paths utilities', () => {
       const { getUnifiedDataFilePath, getDataDirectory } = await import('../utils/paths');
       expect(getUnifiedDataFilePath()).toBe(path.join(getDataDirectory(), 'data.json'));
     });
+
+    it('getGlobalStoreDirPath returns store subdirectory inside data directory', async () => {
+      vi.resetModules();
+      const { getGlobalStoreDirPath, getDataDirectory } = await import('../utils/paths');
+      expect(getGlobalStoreDirPath()).toBe(path.join(getDataDirectory(), 'store'));
+    });
+  });
+
+  describe('findProjectStoreDir', () => {
+    it('returns null when CODEX_NO_PROJECT is set', async () => {
+      vi.resetModules();
+      const originalNoProject = process.env.CODEX_NO_PROJECT;
+      process.env.CODEX_NO_PROJECT = '1';
+
+      try {
+        const { findProjectStoreDir, clearProjectFileCache } = await import('../utils/paths');
+        clearProjectFileCache();
+        expect(findProjectStoreDir()).toBeNull();
+      } finally {
+        if (originalNoProject !== undefined) {
+          process.env.CODEX_NO_PROJECT = originalNoProject;
+        } else {
+          delete process.env.CODEX_NO_PROJECT;
+        }
+      }
+    });
+
+    it('honors CODEX_PROJECT pointing at a .codexcli directory', async () => {
+      const projectDir = path.join(tmpDir, '.codexcli');
+      fs.mkdirSync(projectDir);
+      vi.resetModules();
+      const original = process.env.CODEX_PROJECT;
+      process.env.CODEX_PROJECT = projectDir;
+      try {
+        const { findProjectStoreDir, clearProjectFileCache } = await import('../utils/paths');
+        clearProjectFileCache();
+        expect(findProjectStoreDir()).toBe(projectDir);
+      } finally {
+        if (original !== undefined) process.env.CODEX_PROJECT = original;
+        else delete process.env.CODEX_PROJECT;
+      }
+    });
+
+    it('honors CODEX_PROJECT pointing at a containing directory', async () => {
+      fs.mkdirSync(path.join(tmpDir, '.codexcli'));
+      vi.resetModules();
+      const original = process.env.CODEX_PROJECT;
+      process.env.CODEX_PROJECT = tmpDir;
+      try {
+        const { findProjectStoreDir, clearProjectFileCache } = await import('../utils/paths');
+        clearProjectFileCache();
+        expect(findProjectStoreDir()).toBe(path.join(tmpDir, '.codexcli'));
+      } finally {
+        if (original !== undefined) process.env.CODEX_PROJECT = original;
+        else delete process.env.CODEX_PROJECT;
+      }
+    });
+
+    it('fails closed when CODEX_PROJECT does not resolve to a directory', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_PROJECT;
+      process.env.CODEX_PROJECT = path.join(tmpDir, 'nonexistent');
+      try {
+        const { findProjectStoreDir, clearProjectFileCache } = await import('../utils/paths');
+        clearProjectFileCache();
+        expect(findProjectStoreDir()).toBeNull();
+      } finally {
+        if (original !== undefined) process.env.CODEX_PROJECT = original;
+        else delete process.env.CODEX_PROJECT;
+      }
+    });
+
+    it('walks up from setProjectRootOverride to find .codexcli directory', async () => {
+      const nested = path.join(tmpDir, 'a', 'b', 'c');
+      fs.mkdirSync(nested, { recursive: true });
+      fs.mkdirSync(path.join(tmpDir, '.codexcli'));
+
+      vi.resetModules();
+      const { findProjectStoreDir, clearProjectFileCache, setProjectRootOverride } = await import('../utils/paths');
+      clearProjectFileCache();
+      setProjectRootOverride(nested);
+      try {
+        expect(findProjectStoreDir()).toBe(path.join(tmpDir, '.codexcli'));
+      } finally {
+        setProjectRootOverride(null);
+      }
+    });
+
+    it('does not match a file named .codexcli (only directories)', async () => {
+      fs.writeFileSync(path.join(tmpDir, '.codexcli'), 'not a dir');
+
+      vi.resetModules();
+      const { findProjectStoreDir, clearProjectFileCache, setProjectRootOverride } = await import('../utils/paths');
+      clearProjectFileCache();
+      setProjectRootOverride(tmpDir);
+      try {
+        expect(findProjectStoreDir()).toBeNull();
+      } finally {
+        setProjectRootOverride(null);
+      }
+    });
   });
 });

--- a/src/__tests__/store.test.ts
+++ b/src/__tests__/store.test.ts
@@ -1,8 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { writeDirectoryStore, readDirectoryStore } from './helpers/readStoreState';
 
 let tmpDir: string;
+let storeDir: string;
 let dataPath: string;
 
 vi.mock('../utils/paths', () => ({
@@ -10,10 +12,12 @@ vi.mock('../utils/paths', () => ({
   getUnifiedDataFilePath: () => path.join(tmpDir, 'data.json'),
   getAliasFilePath: () => path.join(tmpDir, 'aliases.json'),
   getConfirmFilePath: () => path.join(tmpDir, 'confirm.json'),
+  getGlobalStoreDirPath: () => path.join(tmpDir, 'store'),
   ensureDataDirectoryExists: () => {
     if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
   },
   findProjectFile: () => null,
+  findProjectStoreDir: () => null,
   clearProjectFileCache: () => {},
 }));
 
@@ -28,6 +32,7 @@ import {
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-store-'));
+  storeDir = path.join(tmpDir, 'store');
   dataPath = path.join(tmpDir, 'data.json');
   clearStoreCaches();
 });
@@ -36,14 +41,20 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-// ── Helper ────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────
+//
+// v1.10.0: `writeData`/`readData` interact with the new file-per-entry store
+// directory so tests can continue asserting against a legacy-shaped object
+// without caring about the wrapper-file format. Tests that specifically
+// exercise the legacy→directory migration path write raw `data.json` directly
+// (bypassing these helpers) and assert against the resulting store directory.
 
 function writeData(data: Record<string, unknown>): void {
-  fs.writeFileSync(dataPath, JSON.stringify(data));
+  writeDirectoryStore(storeDir, data);
 }
 
 function readData(): Record<string, unknown> {
-  return JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  return readDirectoryStore(storeDir) as Record<string, unknown>;
 }
 
 // ── ScopedStore: load/save cycle ─────────────────────────────────────
@@ -89,7 +100,8 @@ describe('ScopedStore load/save cycle', () => {
     clearStoreCaches();
 
     saveAliasMap({ zulu: 'z.key', alpha: 'a.key' }, 'global');
-    const raw = fs.readFileSync(dataPath, 'utf8');
+    // v1.10.0: aliases now live in a sidecar `_aliases.json` inside store/
+    const raw = fs.readFileSync(path.join(storeDir, '_aliases.json'), 'utf8');
     const alphaIdx = raw.indexOf('"alpha"');
     const zuluIdx = raw.indexOf('"zulu"');
     expect(alphaIdx).toBeLessThan(zuluIdx);
@@ -103,9 +115,13 @@ describe('mtime caching', () => {
     writeData({ entries: { x: '1' }, aliases: {}, confirm: {} });
     clearStoreCaches();
 
+    // v1.10.0: the directory store assembles a fresh UnifiedData object on
+    // each load(), so reference equality no longer holds. What matters is
+    // that repeated loads return structurally equal data without re-reading
+    // entry files whose mtimes haven't changed.
     const first = loadEntries('global');
     const second = loadEntries('global');
-    expect(first).toBe(second); // same reference = cache hit
+    expect(second).toEqual(first);
   });
 
   it('invalidates cache when file is externally modified', () => {
@@ -114,13 +130,13 @@ describe('mtime caching', () => {
 
     loadEntries('global');
 
-    // External modification (simulate another process)
-    const newContent = JSON.stringify({ entries: { x: '2' }, aliases: {}, confirm: {} });
-    // Need a different mtime — touch after a small delay
-    const originalMtime = fs.statSync(dataPath).mtimeMs;
-    // Force different mtime
-    fs.writeFileSync(dataPath, newContent);
-    const fd = fs.openSync(dataPath, 'r+');
+    // External modification (simulate another process) — write a new wrapper
+    // to the entry file with a different mtime. The per-file mtime cache
+    // should detect the change on the next load().
+    const entryPath = path.join(storeDir, 'x.json');
+    const originalMtime = fs.statSync(entryPath).mtimeMs;
+    fs.writeFileSync(entryPath, JSON.stringify({ value: '2' }));
+    const fd = fs.openSync(entryPath, 'r+');
     fs.futimesSync(fd, new Date(), new Date(originalMtime + 1000));
     fs.closeSync(fd);
 
@@ -186,14 +202,18 @@ describe('error recovery', () => {
   });
 
   it('treats file without entries key as legacy and migrates it', () => {
-    // A file without an "entries" key is treated as legacy (entries-only format)
-    // The entire content becomes the entries
-    writeData({ aliases: { x: 'y' }, confirm: {} });
+    // A unified file without an "entries" key is treated as legacy
+    // (entries-only format from the pre-unified era). The entire content
+    // becomes the entries. The v1.10.0 migration then converts the resulting
+    // unified file to the per-entry directory layout in a second step. Note
+    // that the flatten→unflatten roundtrip prunes empty subtrees like
+    // `confirm: {}`, so only string-leaf branches survive — this matches the
+    // documented file-per-entry semantics.
+    fs.writeFileSync(dataPath, JSON.stringify({ aliases: { x: 'y' }, confirm: {} }));
     clearStoreCaches();
 
     const entries = loadEntries('global');
-    // Legacy migration wraps the entire content as entries
-    expect(entries).toEqual({ aliases: { x: 'y' }, confirm: {} });
+    expect(entries).toEqual({ aliases: { x: 'y' } });
   });
 });
 
@@ -240,15 +260,20 @@ describe('meta operations', () => {
   });
 
   it('saveEntriesAndRemoveMeta removes key and children', () => {
+    // v1.10.0: meta lives inside entry wrapper files, so there's no such
+    // thing as "meta for a key that has no entry". Every meta key must have
+    // a corresponding leaf entry. Added `other` as a real leaf so its meta
+    // has a home.
     writeData({
-      entries: { srv: { ip: '1' } },
+      entries: { srv: { ip: '1' }, other: 'val' },
       aliases: {},
       confirm: {},
-      _meta: { 'srv': 100, 'srv.ip': 200, 'other': 300 },
+      _meta: { 'srv.ip': 200, 'other': 300 },
     });
     clearStoreCaches();
 
-    saveEntriesAndRemoveMeta({}, 'srv', 'global');
+    // Keep `other` in the new entries state so its meta is preserved
+    saveEntriesAndRemoveMeta({ other: 'val' }, 'srv', 'global');
 
     const meta = loadMeta('global');
     expect(meta['srv']).toBeUndefined();
@@ -309,7 +334,8 @@ describe('merged accessors (global-only, no project)', () => {
   });
 
   it('loadMetaMerged returns global meta when no project', () => {
-    writeData({ entries: {}, aliases: {}, confirm: {}, _meta: { k: 123 } });
+    // v1.10.0: meta lives inside entry files, so `k` needs a real entry.
+    writeData({ entries: { k: 'v' }, aliases: {}, confirm: {}, _meta: { k: 123 } });
     clearStoreCaches();
 
     expect(loadMetaMerged()).toEqual({ k: 123 });

--- a/src/__tests__/storeMeta.test.ts
+++ b/src/__tests__/storeMeta.test.ts
@@ -1,19 +1,22 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { writeDirectoryStore, readDirectoryStore } from './helpers/readStoreState';
 
 let tmpDir: string;
-let dataPath: string;
+let storeDir: string;
 
 vi.mock('../utils/paths', () => ({
   getDataDirectory: () => tmpDir,
   getUnifiedDataFilePath: () => path.join(tmpDir, 'data.json'),
   getAliasFilePath: () => path.join(tmpDir, 'aliases.json'),
   getConfirmFilePath: () => path.join(tmpDir, 'confirm.json'),
+  getGlobalStoreDirPath: () => path.join(tmpDir, 'store'),
   ensureDataDirectoryExists: () => {
     if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
   },
   findProjectFile: () => null,
+  findProjectStoreDir: () => null,
   clearProjectFileCache: () => {},
 }));
 
@@ -21,7 +24,7 @@ import { loadMeta, touchMeta, removeMeta, loadEntries, saveEntries, clearStoreCa
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-meta-'));
-  dataPath = path.join(tmpDir, 'data.json');
+  storeDir = path.join(tmpDir, 'store');
   clearStoreCaches();
 });
 
@@ -31,24 +34,21 @@ afterEach(() => {
 
 describe('store meta operations', () => {
   it('touchMeta writes a timestamp for the key', () => {
-    fs.writeFileSync(dataPath, JSON.stringify({ entries: { foo: 'bar' }, aliases: {}, confirm: {} }));
+    writeDirectoryStore(storeDir, { entries: { foo: 'bar' } });
     clearStoreCaches();
 
     touchMeta('foo', 'global');
 
-    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8')) as Record<string, unknown>;
-    const meta = data._meta as Record<string, number>;
+    const meta = loadMeta('global');
     expect(meta.foo).toBeGreaterThan(0);
   });
 
   it('loadMeta returns stored timestamps', () => {
     const now = Date.now();
-    fs.writeFileSync(dataPath, JSON.stringify({
+    writeDirectoryStore(storeDir, {
       entries: { foo: 'bar' },
-      aliases: {},
-      confirm: {},
       _meta: { foo: now },
-    }));
+    });
     clearStoreCaches();
 
     const meta = loadMeta('global');
@@ -56,7 +56,7 @@ describe('store meta operations', () => {
   });
 
   it('loadMeta returns empty object when no _meta exists', () => {
-    fs.writeFileSync(dataPath, JSON.stringify({ entries: {}, aliases: {}, confirm: {} }));
+    writeDirectoryStore(storeDir, { entries: {} });
     clearStoreCaches();
 
     const meta = loadMeta('global');
@@ -64,12 +64,13 @@ describe('store meta operations', () => {
   });
 
   it('removeMeta deletes key and children', () => {
-    fs.writeFileSync(dataPath, JSON.stringify({
-      entries: {},
-      aliases: {},
-      confirm: {},
+    writeDirectoryStore(storeDir, {
+      entries: {
+        server: { ip: '1.2.3.4', port: '8080' },
+        other: 'value',
+      },
       _meta: { 'server': 100, 'server.ip': 200, 'server.port': 300, 'other': 400 },
-    }));
+    });
     clearStoreCaches();
 
     removeMeta('server', 'global');
@@ -83,30 +84,32 @@ describe('store meta operations', () => {
 
   it('_meta is preserved through save/load cycle', () => {
     const now = Date.now();
-    fs.writeFileSync(dataPath, JSON.stringify({
+    writeDirectoryStore(storeDir, {
       entries: { foo: 'bar' },
-      aliases: {},
-      confirm: {},
       _meta: { foo: now },
-    }));
+    });
     clearStoreCaches();
 
     const entries = loadEntries('global');
     entries.baz = 'qux';
     saveEntries(entries, 'global');
 
-    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8')) as Record<string, unknown>;
-    expect((data._meta as Record<string, number>).foo).toBe(now);
+    const meta = loadMeta('global');
+    expect(meta.foo).toBe(now);
   });
 
-  it('_meta is not written when empty', () => {
-    fs.writeFileSync(dataPath, JSON.stringify({ entries: { foo: 'bar' }, aliases: {}, confirm: {} }));
+  it('meta is not written for untracked entries', () => {
+    writeDirectoryStore(storeDir, { entries: { foo: 'bar' } });
     clearStoreCaches();
 
+    // Save without a _meta map → the entry file should have no `meta` block
     saveEntries({ foo: 'baz' } as Record<string, unknown>, 'global');
 
-    const raw = fs.readFileSync(dataPath, 'utf8');
-    expect(raw).not.toContain('_meta');
+    const fooFile = JSON.parse(
+      fs.readFileSync(path.join(storeDir, 'foo.json'), 'utf8')
+    ) as { value: string; meta?: unknown };
+    expect(fooFile.value).toBe('baz');
+    expect(fooFile.meta).toBeUndefined();
   });
 });
 

--- a/src/commands/data-management.ts
+++ b/src/commands/data-management.ts
@@ -337,8 +337,9 @@ export function handleProjectFile(options: {
   // Check for the edge case where target exists but is not a directory
   // (e.g. a leftover legacy file). mkdirSync would throw EEXIST in that case.
   if (targetStat !== null && !targetStat.isDirectory()) {
+    const kind = targetStat.isFile() ? 'file' : targetStat.isSymbolicLink() ? 'symlink' : 'non-directory';
     printError(
-      `Cannot initialize: '${target}' already exists as a non-directory file. ` +
+      `Cannot initialize: '${target}' already exists as a ${kind}. ` +
       `Remove it manually before running 'ccli init'.`
     );
     return;

--- a/src/commands/data-management.ts
+++ b/src/commands/data-management.ts
@@ -12,7 +12,6 @@ import { maskEncryptedValues } from '../utils/crypto';
 import { debug } from '../utils/debug';
 import { createAutoBackup } from '../utils/autoBackup';
 import { findProjectFile, clearProjectFileCache } from '../store';
-import { saveJsonSorted } from '../utils/saveJsonSorted';
 import { getAuditPath } from '../utils/audit';
 import { getTelemetryPath, getMissPathsPath } from '../utils/telemetry';
 import { scanCodebase, ScaffoldEntry } from './scan';
@@ -313,25 +312,30 @@ export function handleProjectFile(options: {
   dryRun?: boolean;
 }): void {
   if (options.remove) {
-    const projectFile = findProjectFile();
-    if (!projectFile) {
-      printError('No .codexcli.json found in current directory tree.');
+    const projectPath = findProjectFile();
+    if (!projectPath) {
+      printError('No .codexcli project store found in current directory tree.');
       return;
     }
-    fs.unlinkSync(projectFile);
+    // findProjectFile may return either a legacy .codexcli.json file or a
+    // v1.10.0 .codexcli/ directory. rmSync handles both uniformly.
+    fs.rmSync(projectPath, { recursive: true, force: true });
     clearProjectFileCache();
-    printSuccess(`Removed: ${projectFile}`);
+    printSuccess(`Removed: ${projectPath}`);
     return;
   }
 
   const cwd = process.cwd();
-  const target = path.join(cwd, '.codexcli.json');
-  const existed = fs.existsSync(target);
+  const target = path.join(cwd, '.codexcli');
+  const existed = fs.existsSync(target) && fs.statSync(target).isDirectory();
 
-  // Create .codexcli.json if it doesn't exist
+  // Create .codexcli/ directory with empty sidecars if it doesn't exist
   if (!existed) {
     if (!options.dryRun) {
-      saveJsonSorted(target, { entries: {}, aliases: {}, confirm: {} });
+      fs.mkdirSync(target, { recursive: true, mode: 0o700 });
+      // Seed empty sidecars so the store has a consistent initial state
+      fs.writeFileSync(path.join(target, '_aliases.json'), '{}\n', { mode: 0o600 });
+      fs.writeFileSync(path.join(target, '_confirm.json'), '{}\n', { mode: 0o600 });
       clearProjectFileCache();
     }
     printSuccess(`Created: ${target}`);

--- a/src/commands/data-management.ts
+++ b/src/commands/data-management.ts
@@ -301,7 +301,7 @@ function showImportPreview(type: string, validData: Record<string, unknown>, mer
   console.log(color.gray('\nThis is a preview. No data was modified.'));
 }
 
-const PERSISTENCE_VALUE = '.codexcli.json = project knowledge (any agent). CLAUDE.md = Claude behavioral directives. MEMORY.md = personal user preferences. Rule: if another agent would benefit, it belongs in .codexcli.json.';
+const PERSISTENCE_VALUE = '.codexcli/ = project knowledge store (any agent, file-per-entry layout). CLAUDE.md = Claude behavioral directives. MEMORY.md = personal user preferences. Rule: if another agent would benefit, it belongs in .codexcli/.';
 
 export function handleProjectFile(options: {
   remove?: boolean;

--- a/src/commands/data-management.ts
+++ b/src/commands/data-management.ts
@@ -327,7 +327,24 @@ export function handleProjectFile(options: {
 
   const cwd = process.cwd();
   const target = path.join(cwd, '.codexcli');
-  const existed = fs.existsSync(target) && fs.statSync(target).isDirectory();
+
+  // Single stat call to determine the target's state.
+  let targetStat: ReturnType<typeof fs.statSync> | null = null;
+  try {
+    targetStat = fs.statSync(target);
+  } catch { /* ENOENT — target doesn't exist yet */ }
+
+  // Check for the edge case where target exists but is not a directory
+  // (e.g. a leftover legacy file). mkdirSync would throw EEXIST in that case.
+  if (targetStat !== null && !targetStat.isDirectory()) {
+    printError(
+      `Cannot initialize: '${target}' already exists as a non-directory file. ` +
+      `Remove it manually before running 'ccli init'.`
+    );
+    return;
+  }
+
+  const existed = targetStat !== null;
 
   // Create .codexcli/ directory with empty sidecars if it doesn't exist
   if (!existed) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -5,7 +5,7 @@ import { version } from '../../package.json';
 import { getEntriesFlat } from '../storage';
 import { loadAliases } from '../alias';
 import { loadConfirmKeys } from '../confirm';
-import { getUnifiedDataFilePath, getConfigFilePath } from '../utils/paths';
+import { getGlobalStoreDirPath, getConfigFilePath } from '../utils/paths';
 import { findProjectFile } from '../store';
 import { color } from '../formatting';
 import { getBinaryName } from '../utils/binaryName';
@@ -29,7 +29,7 @@ export function showInfo(): void {
 
   console.log();
 
-  label('Data', getUnifiedDataFilePath());
+  label('Data', getGlobalStoreDirPath());
   label('Config', getConfigFilePath());
   const projectFile = findProjectFile();
   label('Project', projectFile ?? color.gray('none'));

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -2,6 +2,7 @@ import { getEntriesFlat, Scope } from '../storage';
 import { color } from '../formatting';
 import { findProjectFile } from '../store';
 import fs from 'fs';
+import path from 'path';
 
 const DEFAULT_NAMESPACES = ['project', 'commands', 'arch', 'conventions', 'context', 'files', 'deps', 'system'];
 
@@ -9,6 +10,10 @@ function loadCustomSchema(): string[] | null {
   const projectFile = findProjectFile();
   if (!projectFile) return null;
   try {
+    // In v1.10.0, findProjectFile() may return a directory path (.codexcli/).
+    // Detect by basename rather than fs.statSync to stay mock-friendly in tests.
+    // The _schema feature is not implemented for the directory layout yet.
+    if (path.basename(projectFile) === '.codexcli') return null;
     const raw = JSON.parse(fs.readFileSync(projectFile, 'utf8')) as Record<string, unknown>;
     const schema = raw._schema as { namespaces?: string[] } | undefined;
     return schema?.namespaces ?? null;

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -10,8 +10,9 @@ function loadCustomSchema(): string[] | null {
   const projectFile = findProjectFile();
   if (!projectFile) return null;
   try {
-    // In v1.10.0, findProjectFile() may return a directory path (.codexcli/).
-    // Detect by basename rather than fs.statSync to stay mock-friendly in tests.
+    // In v1.10.0, findProjectFile() returns a directory path when the new layout
+    // is in use (.codexcli/ directory). Detect this by basename — the directory
+    // has no extension, while the legacy file ends in .json.
     // The _schema feature is not implemented for the directory layout yet.
     if (path.basename(projectFile) === '.codexcli') return null;
     const raw = JSON.parse(fs.readFileSync(projectFile, 'utf8')) as Record<string, unknown>;

--- a/src/llm-instructions.ts
+++ b/src/llm-instructions.ts
@@ -19,8 +19,8 @@ SCHEMA (recommended namespaces):
 - deps.*         — notable dependencies and why they are used
 
 SCOPE:
-- If a .codexcli.json project file exists, reads/writes default to the project scope.
-- Use scope: "global" to target the user's personal global store (~/.codexcli/data.json).
+- If a .codexcli/ project store directory exists, reads/writes default to the project scope.
+- Use scope: "global" to target the user's personal global store (~/.codexcli/store/).
 - codex_get with no key shows project entries by default. Pass all: true to see both scopes.
 
 TOOLS (19 total):
@@ -62,9 +62,9 @@ FRESHNESS:
 - Run codex_stale after codex_context to audit knowledge freshness when starting a new task.
 
 PREFER MCP TOOLS:
-- Always interact with the data store via MCP tools (codex_get, codex_set, codex_search, etc.) rather than reading .codexcli.json directly.
+- Always interact with the data store via MCP tools (codex_get, codex_set, codex_search, etc.) rather than reading .codexcli/*.json directly.
 - Direct file reads bypass audit logging, alias resolution, interpolation, and scope fallthrough.
-- The only reason to read .codexcli.json directly is debugging the MCP server itself.
+- Hand-editing .codexcli/*.json files is unsupported — it desyncs per-entry meta (staleness timestamps) and breaks the wrapper format. Use the CLI or MCP tools.
 
 EFFECTIVE USAGE:
 - Always call codex_context as your FIRST tool call to bootstrap session knowledge.

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,7 +9,7 @@ import { debug } from './utils/debug';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-interface UnifiedData {
+export interface UnifiedData {
   entries: CodexData;
   aliases: Record<string, string>;
   confirm: Record<string, true>;
@@ -21,7 +21,7 @@ export type Scope = 'project' | 'global' | 'auto';
 
 // ── ScopedStore ────────────────────────────────────────────────────────
 
-interface ScopedStore {
+export interface ScopedStore {
   load(): UnifiedData;
   save(data: UnifiedData): void;
   clear(): void;

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,7 +36,6 @@ export interface ScopedStore {
   load(): UnifiedData;
   save(data: UnifiedData): void;
   clear(): void;
-  prime(data: UnifiedData, mtime: number): void;
 }
 
 // ── Global store singleton ─────────────────────────────────────────────
@@ -76,6 +75,16 @@ function getGlobalStore(): ScopedStore {
         migrateFileToDirectory(getUnifiedDataFilePath(), getGlobalStoreDirPath());
       } catch (err) {
         debug(`Unified→directory migration error (global): ${String(err)}`);
+        // If migration failed and the store directory doesn't exist, the user's
+        // existing data.json would be invisible to the directory store. Warn so
+        // the failure is actionable rather than silently presenting an empty store.
+        if (!fs.existsSync(getGlobalStoreDirPath())) {
+          console.warn(
+            `[codexCLI] Warning: store migration failed and no store directory was created. ` +
+            `Your existing data may be inaccessible until migration succeeds. ` +
+            `Error: ${String(err)}`
+          );
+        }
       }
       migrationDone = true;
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,10 +1,21 @@
 import fs from 'fs';
 import path from 'path';
 import { CodexData } from './types';
-import { getUnifiedDataFilePath, getDataDirectory, getAliasFilePath, getConfirmFilePath, ensureDataDirectoryExists, findProjectFile, clearProjectFileCache } from './utils/paths';
+import {
+  getUnifiedDataFilePath,
+  getDataDirectory,
+  getAliasFilePath,
+  getConfirmFilePath,
+  getGlobalStoreDirPath,
+  ensureDataDirectoryExists,
+  findProjectFile,
+  findProjectStoreDir,
+  clearProjectFileCache,
+} from './utils/paths';
 
 export { findProjectFile, clearProjectFileCache } from './utils/paths';
 import { saveJsonSorted } from './utils/saveJsonSorted';
+import { createDirectoryStore, migrateFileToDirectory } from './utils/directoryStore';
 import { debug } from './utils/debug';
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -28,101 +39,47 @@ export interface ScopedStore {
   prime(data: UnifiedData, mtime: number): void;
 }
 
-function createScopedStore(getFilePath: () => string, ensureDir: () => void): ScopedStore {
-  let cache: UnifiedData | null = null;
-  let cacheMtime: number | null = null;
-
-  function clear(): void {
-    cache = null;
-    cacheMtime = null;
-  }
-
-  function load(): UnifiedData {
-    const filePath = getFilePath();
-
-    // Fast path: mtime cache hit
-    if (cache !== null && cacheMtime !== null) {
-      try {
-        if (fs.statSync(filePath).mtimeMs === cacheMtime) {
-          return cache;
-        }
-      } catch {
-        clear();
-      }
-    }
-
-    try {
-      const currentMtime = fs.statSync(filePath).mtimeMs;
-      const raw = fs.readFileSync(filePath, 'utf8');
-      const parsed = (raw?.trim() ? JSON.parse(raw) : {}) as Record<string, unknown>;
-
-      const result: UnifiedData = {
-        entries: (parsed.entries ?? {}) as CodexData,
-        aliases: (parsed.aliases ?? {}) as Record<string, string>,
-        confirm: (parsed.confirm ?? {}) as Record<string, true>,
-        _meta: (parsed._meta ?? undefined) as Record<string, number> | undefined,
-      };
-
-      cache = result;
-      cacheMtime = currentMtime;
-      return result;
-    } catch (error) {
-      // File doesn't exist — return empty data
-      if (error && typeof error === 'object' && 'code' in error && (error as { code: string }).code === 'ENOENT') {
-        return { entries: {}, aliases: {}, confirm: {} };
-      }
-      if (!(error instanceof SyntaxError && error.message.includes('Unexpected end'))) {
-        console.error('Error loading data:', error);
-      }
-      return { entries: {}, aliases: {}, confirm: {} };
-    }
-  }
-
-  function save(data: UnifiedData): void {
-    const filePath = getFilePath();
-    try {
-      ensureDir();
-      // Sort each section's keys before saving
-      const sorted: Record<string, unknown> = {
-        aliases: Object.fromEntries(Object.entries(data.aliases).sort(([a], [b]) => a.localeCompare(b))),
-        confirm: Object.fromEntries(Object.entries(data.confirm).sort(([a], [b]) => a.localeCompare(b))),
-        entries: data.entries, // entries are nested — saveJsonSorted handles top-level sort
-      };
-      if (data._meta && Object.keys(data._meta).length > 0) {
-        sorted._meta = Object.fromEntries(Object.entries(data._meta).sort(([a], [b]) => a.localeCompare(b)));
-      }
-      saveJsonSorted(filePath, sorted);
-      const mtime = fs.statSync(filePath).mtimeMs;
-      cache = data;
-      cacheMtime = mtime;
-    } catch (error) {
-      console.error('Error saving data:', error);
-    }
-  }
-
-  function prime(data: UnifiedData, mtime: number): void {
-    cache = data;
-    cacheMtime = mtime;
-  }
-
-  return { load, save, clear, prime };
-}
-
 // ── Global store singleton ─────────────────────────────────────────────
+//
+// Note: the old `createScopedStore` factory (single-file, mtime-cached) was
+// removed when the file-per-entry layout landed. The store is now always a
+// directory (`createDirectoryStore`). The legacy file migration path remains
+// below — `migrateToUnifiedFile` handles pre-v1.0 layouts, then
+// `migrateFileToDirectory` converts the unified file into the directory.
 
 let globalStore: ScopedStore | null = null;
 let migrationDone = false;
 
+/** Ensure the v1.10.0 global store directory exists. */
+function ensureGlobalStoreDirExists(): void {
+  ensureDataDirectoryExists();  // parent (~/.codexcli/) must exist first
+  const storeDir = getGlobalStoreDirPath();
+  if (!fs.existsSync(storeDir)) {
+    fs.mkdirSync(storeDir, { recursive: true, mode: 0o700 });
+  }
+}
+
 function getGlobalStore(): ScopedStore {
   if (!globalStore) {
-    globalStore = createScopedStore(getUnifiedDataFilePath, ensureDataDirectoryExists);
     if (!migrationDone) {
-      const primed = migrateToUnifiedFile();
-      if (primed) {
-        globalStore.prime(primed.data, primed.mtime);
+      // Two-stage migration chain:
+      //   1. Legacy → unified: handles pre-v1.0 data (entries.json + aliases.json + confirm.json)
+      //      and the pre-rename data.json format. Produces a unified .codexcli/data.json.
+      //   2. Unified → directory (v1.10.0): converts the unified file to the file-per-entry
+      //      layout at ~/.codexcli/store/. This is the new canonical layout.
+      try {
+        migrateToUnifiedFile();
+      } catch (err) {
+        debug(`Legacy→unified migration error: ${String(err)}`);
+      }
+      try {
+        migrateFileToDirectory(getUnifiedDataFilePath(), getGlobalStoreDirPath());
+      } catch (err) {
+        debug(`Unified→directory migration error (global): ${String(err)}`);
       }
       migrationDone = true;
     }
+    globalStore = createDirectoryStore(getGlobalStoreDirPath, ensureGlobalStoreDirExists);
   }
   return globalStore;
 }
@@ -130,32 +87,51 @@ function getGlobalStore(): ScopedStore {
 // ── Project store singleton ────────────────────────────────────────────
 
 let projectStore: ScopedStore | null = null;
-let projectStorePath: string | null = null;
+let projectStoreDirPath: string | null = null;
 
 function getProjectStore(): ScopedStore | null {
-  const projectFile = findProjectFile();
-  if (!projectFile) {
+  // v1.10.0 on-demand migration: if no `.codexcli/` directory is found but a
+  // legacy `.codexcli.json` file exists at the same logical location, convert
+  // it in place before resolving the store.
+  let projectDir = findProjectStoreDir();
+
+  if (!projectDir) {
+    const legacyPath = findProjectFile();
+    // findProjectFile may return either a file or a directory. We only want to
+    // trigger migration if it's specifically a legacy `.codexcli.json` file.
+    if (legacyPath && path.basename(legacyPath) === '.codexcli.json') {
+      const newDir = path.join(path.dirname(legacyPath), '.codexcli');
+      try {
+        const result = migrateFileToDirectory(legacyPath, newDir);
+        if (result.status === 'migrated') {
+          debug(`Migrated project store: ${legacyPath} -> ${newDir}`);
+        }
+        clearProjectFileCache();
+        projectDir = findProjectStoreDir();
+      } catch (err) {
+        debug(`Project store migration failed for ${legacyPath}: ${String(err)}`);
+      }
+    }
+  }
+
+  if (!projectDir) {
     projectStore = null;
-    projectStorePath = null;
+    projectStoreDirPath = null;
     return null;
   }
 
-  // If the path changed (shouldn't normally happen within one process), recreate
-  if (projectStorePath !== projectFile) {
-    let dirEnsured = false;
-    projectStore = createScopedStore(
-      () => projectFile,
+  // Recreate the store if the resolved directory changed (rare within one process).
+  if (projectStoreDirPath !== projectDir) {
+    const resolved = projectDir;  // local const so closures capture a non-null string
+    projectStore = createDirectoryStore(
+      () => resolved,
       () => {
-        if (!dirEnsured) {
-          const dir = path.dirname(projectFile);
-          if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-          }
-          dirEnsured = true;
+        if (!fs.existsSync(resolved)) {
+          fs.mkdirSync(resolved, { recursive: true, mode: 0o700 });
         }
       }
     );
-    projectStorePath = projectFile;
+    projectStoreDirPath = resolved;
   }
 
   return projectStore;
@@ -249,7 +225,7 @@ export function clearStoreCaches(): void {
   // Reset singletons so migration re-runs on next access
   globalStore = null;
   projectStore = null;
-  projectStorePath = null;
+  projectStoreDirPath = null;
   migrationDone = false;
   clearProjectFileCache();
 }

--- a/src/utils/autoBackup.ts
+++ b/src/utils/autoBackup.ts
@@ -21,10 +21,20 @@ export function createAutoBackup(label: string): string | null {
     const backupSubDir = path.join(backupDir, `${label}-${timestamp}`);
     fs.mkdirSync(backupSubDir, { mode: 0o700 });
 
-    const filesToBackup = ['data.json', 'entries.json', 'aliases.json', 'confirm.json'];
     let backedUp = 0;
 
-    for (const file of filesToBackup) {
+    // v1.10.0 store directory — copied recursively
+    const storeDir = path.join(dataDir, 'store');
+    if (fs.existsSync(storeDir) && fs.statSync(storeDir).isDirectory()) {
+      const destStore = path.join(backupSubDir, 'store');
+      fs.cpSync(storeDir, destStore, { recursive: true });
+      backedUp++;
+    }
+
+    // Legacy files — may still exist pre-migration or as .backup artifacts
+    // post-migration. Back them up alongside the new store directory.
+    const legacyFiles = ['data.json', 'entries.json', 'aliases.json', 'confirm.json'];
+    for (const file of legacyFiles) {
       const src = path.join(dataDir, file);
       if (fs.existsSync(src)) {
         const dest = path.join(backupSubDir, file);

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -1,0 +1,352 @@
+/**
+ * File-per-entry directory store (v1.10.0 layout).
+ *
+ * Each entry lives in `<dir>/<dotted-key>.json` as a wrapper of the form
+ * `{ value, meta?: { created?, updated? } }`. Store-level state lives in
+ * sidecar files `_aliases.json` and `_confirm.json`. The lock file lives
+ * *outside* the directory at `<dir>.lock` so bulk-op atomicity swaps can
+ * rename the directory itself without clobbering the lock.
+ *
+ * This module implements the `ScopedStore` interface defined in `../store`,
+ * so it is a drop-in replacement for `createScopedStore` — consumers above
+ * the store layer see the same `UnifiedData` shape on load/save.
+ *
+ * Design and decisions: see GitHub issue #54 and `arch.storeLayout` in the
+ * project codex.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { CodexData, CodexValue } from '../types';
+import type { ScopedStore, UnifiedData } from '../store';
+import { atomicWriteFileSync } from './atomicWrite';
+import { withFileLock } from './fileLock';
+import { flattenObject, expandFlatKeys } from './objectPath';
+import { debug } from './debug';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+/** Optional metadata block inside a per-entry wrapper file. */
+export interface EntryMeta {
+  /** Timestamp of the entry's first write. Preserved across updates. */
+  created?: number;
+  /** Timestamp of the entry's most recent write. Bumped on every write. */
+  updated?: number;
+}
+
+/** On-disk per-entry file format. */
+export interface EntryWrapper {
+  value: CodexValue;
+  meta?: EntryMeta;
+}
+
+/** Cached state of one entry file. */
+interface CachedEntry {
+  wrapper: EntryWrapper;
+  mtimeMs: number;
+}
+
+// ── File layout helpers ────────────────────────────────────────────────
+
+const ALIASES_FILE = '_aliases.json';
+const CONFIRM_FILE = '_confirm.json';
+const ENTRY_FILE_SUFFIX = '.json';
+
+/** True if a filename in the store directory represents an entry (not a sidecar). */
+function isEntryFilename(name: string): boolean {
+  return name.endsWith(ENTRY_FILE_SUFFIX) && !name.startsWith('_');
+}
+
+/** Converts an entry filename (`arch.storage.json`) to its dotted key (`arch.storage`). */
+function keyFromFilename(name: string): string {
+  return name.slice(0, -ENTRY_FILE_SUFFIX.length);
+}
+
+/** Converts a dotted key to its entry file path within the store directory. */
+export function entryFilePath(dir: string, key: string): string {
+  return path.join(dir, key + ENTRY_FILE_SUFFIX);
+}
+
+/** Returns the lock path sibling to the store directory. */
+export function getStoreLockPath(dir: string): string {
+  return dir + '.lock';
+}
+
+// ── Wrapper I/O ────────────────────────────────────────────────────────
+
+/** Parses an entry file's contents into an EntryWrapper. Returns null on parse failure. */
+export function parseEntryWrapper(raw: string): EntryWrapper | null {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!('value' in parsed)) return null;
+    const wrapper: EntryWrapper = { value: parsed.value as CodexValue };
+    if (parsed.meta && typeof parsed.meta === 'object') {
+      // EntryMeta has only optional fields, so `object` satisfies it structurally.
+      wrapper.meta = parsed.meta;
+    }
+    return wrapper;
+  } catch {
+    return null;
+  }
+}
+
+/** Serializes an EntryWrapper to the pretty JSON format used on disk. */
+export function serializeEntryWrapper(wrapper: EntryWrapper): string {
+  return JSON.stringify(wrapper, null, 2);
+}
+
+/** Serializes a sidecar object (aliases or confirm) with sorted keys. */
+function serializeSidecar<T extends Record<string, unknown>>(data: T): string {
+  const sorted = Object.fromEntries(
+    Object.entries(data).sort(([a], [b]) => a.localeCompare(b))
+  );
+  return JSON.stringify(sorted, null, 2);
+}
+
+/** Reads a sidecar file, returning an empty object on ENOENT or parse failure. */
+function readSidecar<T>(filePath: string): T {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return (raw?.trim() ? JSON.parse(raw) : {}) as T;
+  } catch (err) {
+    if (!isENOENT(err)) {
+      debug(`Failed to read sidecar ${filePath}: ${String(err)}`);
+    }
+    return {} as T;
+  }
+}
+
+function isENOENT(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err as { code: string }).code === 'ENOENT'
+  );
+}
+
+// ── Equality helpers ───────────────────────────────────────────────────
+
+/**
+ * Stable deep-equal for CodexValue shapes (string or nested object of strings).
+ * Uses a sorted-key stringify so object key order doesn't affect equality.
+ */
+function stableStringify(v: unknown): string {
+  if (typeof v === 'string') return JSON.stringify(v);
+  if (v && typeof v === 'object') {
+    const keys = Object.keys(v).sort();
+    const parts = keys.map(
+      k => JSON.stringify(k) + ':' + stableStringify((v as Record<string, unknown>)[k])
+    );
+    return '{' + parts.join(',') + '}';
+  }
+  return JSON.stringify(v);
+}
+
+function valueEquals(a: CodexValue, b: CodexValue): boolean {
+  if (a === b) return true;
+  return stableStringify(a) === stableStringify(b);
+}
+
+function shallowEquals<T extends Record<string, unknown>>(a: T, b: T): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+// ── The factory ────────────────────────────────────────────────────────
+
+/**
+ * Create a file-per-entry directory-backed ScopedStore.
+ *
+ * @param getDirPath  Function returning the absolute path to the store directory.
+ * @param ensureDir   Function that ensures the store directory exists on disk
+ *                    (called before any write). Mirrors createScopedStore's contract.
+ */
+export function createDirectoryStore(
+  getDirPath: () => string,
+  ensureDir: () => void
+): ScopedStore {
+  // Per-entry cache, keyed by dotted key. Each entry records its file mtime
+  // so we can detect external writes between load() calls.
+  const entryCache = new Map<string, CachedEntry>();
+  // Sidecar caches — small, not mtime-tracked, refreshed on every scanAndSync().
+  let aliasesCache: Record<string, string> | null = null;
+  let confirmCache: Record<string, true> | null = null;
+
+  function clear(): void {
+    entryCache.clear();
+    aliasesCache = null;
+    confirmCache = null;
+  }
+
+  /**
+   * Scan the directory and refresh caches: re-read any entry whose mtime has
+   * changed, drop cache entries for files that no longer exist, and reload
+   * the sidecars. Must be called with or without the lock depending on caller
+   * context — save() calls it under the lock for authoritative current state.
+   */
+  function scanAndSync(): void {
+    const dir = getDirPath();
+    let files: string[];
+    try {
+      files = fs.readdirSync(dir);
+    } catch (err) {
+      if (isENOENT(err)) {
+        entryCache.clear();
+        aliasesCache = {};
+        confirmCache = {};
+        return;
+      }
+      throw err;
+    }
+
+    const seen = new Set<string>();
+    for (const file of files) {
+      if (!isEntryFilename(file)) continue;
+      const filePath = path.join(dir, file);
+      let mtimeMs: number;
+      try {
+        mtimeMs = fs.statSync(filePath).mtimeMs;
+      } catch {
+        continue;
+      }
+      const key = keyFromFilename(file);
+      seen.add(key);
+      const cached = entryCache.get(key);
+      if (cached?.mtimeMs === mtimeMs) continue;
+      try {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        const wrapper = parseEntryWrapper(raw);
+        if (wrapper) {
+          entryCache.set(key, { wrapper, mtimeMs });
+        } else {
+          debug(`Skipping unparseable entry file: ${filePath}`);
+        }
+      } catch (err) {
+        debug(`Failed to read entry file ${filePath}: ${String(err)}`);
+      }
+    }
+
+    // Drop cache entries for files that no longer exist.
+    for (const key of [...entryCache.keys()]) {
+      if (!seen.has(key)) entryCache.delete(key);
+    }
+
+    // Refresh sidecar caches. Small files, re-read on every scan.
+    aliasesCache = readSidecar<Record<string, string>>(path.join(dir, ALIASES_FILE));
+    confirmCache = readSidecar<Record<string, true>>(path.join(dir, CONFIRM_FILE));
+  }
+
+  function load(): UnifiedData {
+    scanAndSync();
+
+    // Assemble the nested `entries` tree from the flat per-key cache.
+    const flat: Record<string, CodexValue> = {};
+    const meta: Record<string, number> = {};
+    for (const [key, cached] of entryCache) {
+      flat[key] = cached.wrapper.value;
+      if (cached.wrapper.meta?.updated !== undefined) {
+        meta[key] = cached.wrapper.meta.updated;
+      }
+    }
+    const entries = expandFlatKeys(flat) as CodexData;
+
+    const result: UnifiedData = {
+      entries,
+      aliases: aliasesCache ?? {},
+      confirm: confirmCache ?? {},
+    };
+    if (Object.keys(meta).length > 0) {
+      result._meta = meta;
+    }
+    return result;
+  }
+
+  function save(data: UnifiedData): void {
+    const dir = getDirPath();
+    ensureDir();
+
+    withFileLock(getStoreLockPath(dir), () => {
+      // 1. Flatten new entries to leaves (authoritative new state).
+      const newFlat = flattenObject(data.entries as Record<string, unknown>);
+
+      // 2. Re-scan under the lock for authoritative current state.
+      scanAndSync();
+
+      // 3. Compute deltas.
+      const toDelete: string[] = [];
+      for (const key of entryCache.keys()) {
+        if (!(key in newFlat)) toDelete.push(key);
+      }
+      const toWrite: [string, CodexValue, number | undefined][] = [];
+      for (const [key, value] of Object.entries(newFlat)) {
+        const current = entryCache.get(key);
+        const newUpdated = data._meta?.[key];
+        const unchanged =
+          !!current &&
+          valueEquals(current.wrapper.value, value) &&
+          current.wrapper.meta?.updated === newUpdated;
+        if (!unchanged) toWrite.push([key, value, newUpdated]);
+      }
+
+      // 4. Apply deltas. Each atomicWriteFileSync is individually atomic;
+      //    within the directory lock, multi-file writes are serialized against
+      //    other writers (other readers may observe a partial state, but each
+      //    individual file read is atomic so they see consistent values).
+      for (const key of toDelete) {
+        try {
+          fs.unlinkSync(entryFilePath(dir, key));
+        } catch (err) {
+          if (!isENOENT(err)) {
+            debug(`Failed to delete entry file for ${key}: ${String(err)}`);
+          }
+        }
+        entryCache.delete(key);
+      }
+      for (const [key, value, updated] of toWrite) {
+        // Preserve `meta.created` from the existing wrapper if present; set it
+        // to `updated` only on first write. Untracked entries (migrated without
+        // a timestamp) stay bare — no `meta` block at all.
+        const existingCreated = entryCache.get(key)?.wrapper.meta?.created;
+        const wrapper: EntryWrapper = updated !== undefined
+          ? { value, meta: { created: existingCreated ?? updated, updated } }
+          : { value };
+        const filePath = entryFilePath(dir, key);
+        atomicWriteFileSync(filePath, serializeEntryWrapper(wrapper));
+        const mtimeMs = fs.statSync(filePath).mtimeMs;
+        entryCache.set(key, { wrapper, mtimeMs });
+      }
+
+      // 5. Sidecars — rewrite only if changed.
+      if (!aliasesCache || !shallowEquals(aliasesCache, data.aliases)) {
+        atomicWriteFileSync(
+          path.join(dir, ALIASES_FILE),
+          serializeSidecar(data.aliases)
+        );
+        aliasesCache = { ...data.aliases };
+      }
+      if (!confirmCache || !shallowEquals(confirmCache, data.confirm)) {
+        atomicWriteFileSync(
+          path.join(dir, CONFIRM_FILE),
+          serializeSidecar(data.confirm)
+        );
+        confirmCache = { ...data.confirm };
+      }
+    });
+  }
+
+  function prime(): void {
+    // No-op: the new migration path writes the directory directly and lets the
+    // next load() scan fresh. `prime` is kept only to satisfy the ScopedStore
+    // interface during the transition; it will be removed with the old
+    // createScopedStore in a later commit. (TypeScript allows a zero-arg
+    // implementation to satisfy a typed signature with extra positional args.)
+  }
+
+  return { load, save, clear, prime };
+}

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -67,9 +67,13 @@ export function entryFilePath(dir: string, key: string): string {
   return path.join(dir, key + ENTRY_FILE_SUFFIX);
 }
 
-/** Returns the lock path sibling to the store directory. */
-export function getStoreLockPath(dir: string): string {
-  return dir + '.lock';
+/**
+ * Returns the path passed to `withFileLock` for this store. The file-lock
+ * primitive appends `.lock` internally, so callers pass the store directory
+ * itself and the actual lock file ends up as a sibling at `<dir>.lock`.
+ */
+export function getStoreLockKey(dir: string): string {
+  return dir;
 }
 
 // ── Wrapper I/O ────────────────────────────────────────────────────────
@@ -271,7 +275,7 @@ export function createDirectoryStore(
     const dir = getDirPath();
     ensureDir();
 
-    withFileLock(getStoreLockPath(dir), () => {
+    withFileLock(getStoreLockKey(dir), () => {
       // 1. Flatten new entries to leaves (authoritative new state).
       const newFlat = flattenObject(data.entries as Record<string, unknown>);
 

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -68,14 +68,16 @@ function keyFromFilename(name: string): string {
  *   - Is non-empty
  *   - Does not start with `_` (reserved for sidecars like `_aliases`, `_confirm`)
  *   - Contains no path separators (`/`, `\`) — keys are flat filenames, not paths
- *   - Has no empty segment or `..` segment when split on `.`
+ *   - Has no empty segment, `..` segment, or prototype-polluting name (`__proto__`,
+ *     `constructor`, `prototype`) when split on `.`
  */
 export function isValidEntryKey(key: string): boolean {
   if (!key || key.startsWith('_')) return false;
   if (key.includes('/') || key.includes('\\')) return false;
   const parts = key.split('.');
   for (const part of parts) {
-    if (!part || part === '..') return false;
+    if (!part || part === '..' ||
+        part === '__proto__' || part === 'constructor' || part === 'prototype') return false;
   }
   return true;
 }

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -350,3 +350,115 @@ export function createDirectoryStore(
 
   return { load, save, clear, prime };
 }
+
+// ── Migration ──────────────────────────────────────────────────────────
+
+/** Result of a migration attempt. */
+export interface DirectoryMigrationResult {
+  /**
+   * - `no-op`: neither the old file nor the new directory exists (fresh install)
+   * - `already-present`: the new directory already exists (nothing to do)
+   * - `migrated`: successfully converted the old file to the new directory layout
+   */
+  status: 'no-op' | 'already-present' | 'migrated';
+  entryCount: number;
+  backupPath?: string;
+}
+
+/**
+ * Migrate a unified-format store file to the file-per-entry directory layout.
+ *
+ * - If `newDirPath` already exists as a directory: no-op (returns `already-present`).
+ *   If `oldFilePath` also exists alongside it, rename it to `.backup` as cleanup.
+ * - If `oldFilePath` does not exist: no-op (returns `no-op`).
+ * - Otherwise: read the unified file, write per-entry wrapper files and sidecars
+ *   into `newDirPath`, then rename the old file to `<oldFilePath>.backup`.
+ *
+ * The migration preserves each entry's `_meta.updated` timestamp as
+ * `meta.created` AND `meta.updated` in the new wrapper (see design decision #9
+ * in the Phase 1 comment). Untracked entries (no `_meta` timestamp) migrate
+ * with no `meta` block, preserving the `[untracked]` staleness label.
+ *
+ * No locking: migration runs on first store access in a given session, before
+ * any concurrent writers would exist.
+ */
+export function migrateFileToDirectory(
+  oldFilePath: string,
+  newDirPath: string
+): DirectoryMigrationResult {
+  // If the new directory already exists, it's authoritative. Clean up the
+  // old file if it somehow lingers (e.g., aborted prior migration).
+  if (fs.existsSync(newDirPath)) {
+    try {
+      const stat = fs.statSync(newDirPath);
+      if (!stat.isDirectory()) {
+        throw new Error(
+          `Expected ${newDirPath} to be a directory, but found a file. ` +
+          `Resolve this conflict manually before upgrading.`
+        );
+      }
+    } catch (err) {
+      if (!isENOENT(err)) throw err;
+    }
+    if (fs.existsSync(oldFilePath)) {
+      try {
+        fs.renameSync(oldFilePath, oldFilePath + '.backup');
+        debug(`Cleaned up lingering ${oldFilePath} after previous migration`);
+      } catch (err) {
+        debug(`Failed to clean up ${oldFilePath}: ${String(err)}`);
+      }
+    }
+    return { status: 'already-present', entryCount: 0 };
+  }
+
+  if (!fs.existsSync(oldFilePath)) {
+    return { status: 'no-op', entryCount: 0 };
+  }
+
+  // Read and parse the old unified file.
+  let parsed: Record<string, unknown>;
+  try {
+    const raw = fs.readFileSync(oldFilePath, 'utf8');
+    parsed = (raw?.trim() ? JSON.parse(raw) : {}) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse old store file ${oldFilePath}: ${String(err)}. ` +
+      `Fix the JSON manually or delete the file before upgrading.`
+    );
+  }
+
+  const entries = (parsed.entries ?? {}) as CodexData;
+  const aliases = (parsed.aliases ?? {}) as Record<string, string>;
+  const confirm = (parsed.confirm ?? {}) as Record<string, true>;
+  const meta = (parsed._meta ?? {}) as Record<string, number>;
+
+  // Create the new directory (0o700 matches existing ensureDataDirectoryExists).
+  fs.mkdirSync(newDirPath, { recursive: true, mode: 0o700 });
+
+  // Write each entry as a wrapper file.
+  const flat = flattenObject(entries as Record<string, unknown>);
+  let entryCount = 0;
+  for (const [key, value] of Object.entries(flat)) {
+    const updated = meta[key];
+    const wrapper: EntryWrapper = updated !== undefined
+      ? { value, meta: { created: updated, updated } }
+      : { value };  // untracked entries stay bare
+    atomicWriteFileSync(entryFilePath(newDirPath, key), serializeEntryWrapper(wrapper));
+    entryCount++;
+  }
+
+  // Write sidecars (even if empty — lets the store unambiguously report
+  // "aliases: {}" vs "aliases: never-existed").
+  atomicWriteFileSync(path.join(newDirPath, ALIASES_FILE), serializeSidecar(aliases));
+  atomicWriteFileSync(path.join(newDirPath, CONFIRM_FILE), serializeSidecar(confirm));
+
+  // Rename old file to .backup (idempotent if a prior .backup exists: overwrite it).
+  const backupPath = oldFilePath + '.backup';
+  try {
+    if (fs.existsSync(backupPath)) fs.unlinkSync(backupPath);
+  } catch { /* best-effort */ }
+  fs.renameSync(oldFilePath, backupPath);
+
+  debug(`Migrated ${entryCount} entries from ${oldFilePath} to ${newDirPath}`);
+  return { status: 'migrated', entryCount, backupPath };
+}

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -62,9 +62,42 @@ function keyFromFilename(name: string): string {
   return name.slice(0, -ENTRY_FILE_SUFFIX.length);
 }
 
-/** Converts a dotted key to its entry file path within the store directory. */
+/**
+ * Returns true if the key is safe to use as a flat entry filename.
+ * A valid key:
+ *   - Is non-empty
+ *   - Does not start with `_` (reserved for sidecars like `_aliases`, `_confirm`)
+ *   - Contains no path separators (`/`, `\`) — keys are flat filenames, not paths
+ *   - Has no empty segment or `..` segment when split on `.`
+ */
+export function isValidEntryKey(key: string): boolean {
+  if (!key || key.startsWith('_')) return false;
+  if (key.includes('/') || key.includes('\\')) return false;
+  const parts = key.split('.');
+  for (const part of parts) {
+    if (!part || part === '..') return false;
+  }
+  return true;
+}
+
+/**
+ * Converts a dotted key to its entry file path within the store directory.
+ * Throws if the key is invalid (would escape the store directory or collide
+ * with a reserved sidecar name).
+ */
 export function entryFilePath(dir: string, key: string): string {
-  return path.join(dir, key + ENTRY_FILE_SUFFIX);
+  if (!isValidEntryKey(key)) {
+    throw new Error(`Invalid store key: ${JSON.stringify(key)}`);
+  }
+  const filePath = path.join(dir, key + ENTRY_FILE_SUFFIX);
+  // Defense in depth: ensure the resolved path stays inside the store directory.
+  const resolvedDir = path.resolve(dir);
+  const resolvedFile = path.resolve(filePath);
+  const relative = path.relative(resolvedDir, resolvedFile);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Key resolves outside store directory: ${JSON.stringify(key)}`);
+  }
+  return filePath;
 }
 
 /**
@@ -220,6 +253,10 @@ export function createDirectoryStore(
         continue;
       }
       const key = keyFromFilename(file);
+      if (!isValidEntryKey(key)) {
+        debug(`Skipping entry file with unsafe key: ${file}`);
+        continue;
+      }
       seen.add(key);
       const cached = entryCache.get(key);
       if (cached?.mtimeMs === mtimeMs) continue;
@@ -344,15 +381,7 @@ export function createDirectoryStore(
     });
   }
 
-  function prime(): void {
-    // No-op: the new migration path writes the directory directly and lets the
-    // next load() scan fresh. `prime` is kept only to satisfy the ScopedStore
-    // interface during the transition; it will be removed with the old
-    // createScopedStore in a later commit. (TypeScript allows a zero-arg
-    // implementation to satisfy a typed signature with extra positional args.)
-  }
-
-  return { load, save, clear, prime };
+  return { load, save, clear };
 }
 
 // ── Migration ──────────────────────────────────────────────────────────
@@ -436,25 +465,48 @@ export function migrateFileToDirectory(
   const confirm = (parsed.confirm ?? {}) as Record<string, true>;
   const meta = (parsed._meta ?? {}) as Record<string, number>;
 
-  // Create the new directory (0o700 matches existing ensureDataDirectoryExists).
-  fs.mkdirSync(newDirPath, { recursive: true, mode: 0o700 });
+  // Write to a sibling temporary directory first, then atomically rename it to
+  // newDirPath. This ensures that a crash or power loss mid-migration never
+  // leaves a partially-populated newDirPath that would be treated as authoritative
+  // on the next run (the existsSync guard at the top would skip migration if it
+  // found a partially-written newDirPath).
+  const tmpDirPath = newDirPath + '.tmp';
+
+  // Clean up any leftover tmp dir from a previous failed attempt.
+  if (fs.existsSync(tmpDirPath)) {
+    fs.rmSync(tmpDirPath, { recursive: true, force: true });
+  }
+  fs.mkdirSync(tmpDirPath, { recursive: true, mode: 0o700 });
 
   // Write each entry as a wrapper file.
   const flat = flattenObject(entries as Record<string, unknown>);
   let entryCount = 0;
-  for (const [key, value] of Object.entries(flat)) {
-    const updated = meta[key];
-    const wrapper: EntryWrapper = updated !== undefined
-      ? { value, meta: { created: updated, updated } }
-      : { value };  // untracked entries stay bare
-    atomicWriteFileSync(entryFilePath(newDirPath, key), serializeEntryWrapper(wrapper));
-    entryCount++;
-  }
+  try {
+    for (const [key, value] of Object.entries(flat)) {
+      if (!isValidEntryKey(key)) {
+        debug(`Skipping entry with invalid key during migration: ${JSON.stringify(key)}`);
+        continue;
+      }
+      const updated = meta[key];
+      const wrapper: EntryWrapper = updated !== undefined
+        ? { value, meta: { created: updated, updated } }
+        : { value };  // untracked entries stay bare
+      atomicWriteFileSync(entryFilePath(tmpDirPath, key), serializeEntryWrapper(wrapper));
+      entryCount++;
+    }
 
-  // Write sidecars (even if empty — lets the store unambiguously report
-  // "aliases: {}" vs "aliases: never-existed").
-  atomicWriteFileSync(path.join(newDirPath, ALIASES_FILE), serializeSidecar(aliases));
-  atomicWriteFileSync(path.join(newDirPath, CONFIRM_FILE), serializeSidecar(confirm));
+    // Write sidecars (even if empty — lets the store unambiguously report
+    // "aliases: {}" vs "aliases: never-existed").
+    atomicWriteFileSync(path.join(tmpDirPath, ALIASES_FILE), serializeSidecar(aliases));
+    atomicWriteFileSync(path.join(tmpDirPath, CONFIRM_FILE), serializeSidecar(confirm));
+
+    // Atomic swap: rename the fully-written tmp directory to the final path.
+    fs.renameSync(tmpDirPath, newDirPath);
+  } catch (err) {
+    // Clean up the incomplete tmp directory so the next run can retry.
+    try { fs.rmSync(tmpDirPath, { recursive: true, force: true }); } catch { /* best-effort */ }
+    throw err;
+  }
 
   // Rename old file to .backup (idempotent if a prior .backup exists: overwrite it).
   const backupPath = oldFilePath + '.backup';

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -99,14 +99,22 @@ export function setProjectRootOverride(dir: string | null): void {
 }
 
 /**
- * Walk up from cwd to find a .codexcli.json project file.
- * Returns the absolute path if found, null otherwise.
+ * Walk up from cwd to find the project store. As of v1.10.0, this prefers
+ * a `.codexcli/` directory (new format) over a `.codexcli.json` file
+ * (legacy format). Returns the absolute path if either is found, null
+ * otherwise.
  *
  * Resolution order:
  *   1. CODEX_NO_PROJECT env var → disabled (returns null)
- *   2. CODEX_PROJECT env var → explicit path to a .codexcli.json file or its directory
+ *   2. CODEX_PROJECT env var → explicit path to a `.codexcli` directory,
+ *      `.codexcli.json` file, or a containing directory
  *   3. setProjectRootOverride() value (e.g. MCP client roots) → walk up from there
  *   4. process.cwd() → walk up from there
+ *
+ * Callers that need a directory specifically (store internals) should use
+ * `findProjectStoreDir()` instead. Callers that need to *remove* the project
+ * should use `fs.rmSync(path, { recursive: true, force: true })` which handles
+ * both file and directory returns uniformly.
  */
 export function findProjectFile(): string | null {
   if (projectFileCache !== null) {
@@ -119,22 +127,43 @@ export function findProjectFile(): string | null {
     return null;
   }
 
-  // Explicit env var override — file path or containing directory
+  // Explicit env var override — path to a .codexcli directory, .codexcli.json
+  // file, or a containing directory holding either.
   const envPath = process.env.CODEX_PROJECT;
   if (envPath) {
     const resolved = path.resolve(envPath);
-    let candidate = resolved;
+    // Direct hit: resolved IS a .codexcli directory
     try {
-      if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
-        candidate = path.join(resolved, '.codexcli.json');
+      if (
+        fs.existsSync(resolved) &&
+        fs.statSync(resolved).isDirectory() &&
+        path.basename(resolved) === '.codexcli'
+      ) {
+        projectFileCache = resolved;
+        return resolved;
       }
-    } catch {
-      // fall through; existsSync below will handle it
+    } catch { /* fall through */ }
+
+    // Direct hit: resolved IS a .codexcli.json file
+    if (fs.existsSync(resolved) && !isDirectorySafe(resolved)) {
+      projectFileCache = resolved;
+      return resolved;
     }
-    if (fs.existsSync(candidate)) {
-      projectFileCache = candidate;
-      return candidate;
+
+    // Containing directory: look for .codexcli/ or .codexcli.json inside it
+    if (fs.existsSync(resolved) && isDirectorySafe(resolved)) {
+      const dirCandidate = path.join(resolved, '.codexcli');
+      if (fs.existsSync(dirCandidate) && isDirectorySafe(dirCandidate)) {
+        projectFileCache = dirCandidate;
+        return dirCandidate;
+      }
+      const fileCandidate = path.join(resolved, '.codexcli.json');
+      if (fs.existsSync(fileCandidate)) {
+        projectFileCache = fileCandidate;
+        return fileCandidate;
+      }
     }
+
     // Env var was set but didn't resolve — treat as "no project" rather than
     // silently falling back to a different directory the user didn't ask for.
     projectFileCache = '';
@@ -152,10 +181,17 @@ export function findProjectFile(): string | null {
       return null;
     }
 
-    const candidate = path.join(dir, '.codexcli.json');
-    if (fs.existsSync(candidate)) {
-      projectFileCache = candidate;
-      return candidate;
+    // Prefer the new `.codexcli/` directory over the legacy `.codexcli.json` file.
+    const dirCandidate = path.join(dir, '.codexcli');
+    if (fs.existsSync(dirCandidate) && isDirectorySafe(dirCandidate)) {
+      projectFileCache = dirCandidate;
+      return dirCandidate;
+    }
+
+    const fileCandidate = path.join(dir, '.codexcli.json');
+    if (fs.existsSync(fileCandidate)) {
+      projectFileCache = fileCandidate;
+      return fileCandidate;
     }
 
     const parent = path.dirname(dir);
@@ -164,6 +200,15 @@ export function findProjectFile(): string | null {
       return null;
     }
     dir = parent;
+  }
+}
+
+/** Safe wrapper around fs.statSync(...).isDirectory() that returns false on error. */
+function isDirectorySafe(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
   }
 }
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -172,4 +172,106 @@ export function findProjectFile(): string | null {
  */
 export function clearProjectFileCache(): void {
   projectFileCache = null;
+  projectStoreDirCache = null;
+}
+
+// ── v1.10.0 directory store paths ─────────────────────────────────────
+// These are added ahead of the file-per-entry rollout (issue #54) so the
+// migration function has somewhere to write. They do not replace the legacy
+// file getters yet — the transition happens in the store.ts integration
+// commit, after which the legacy getters are kept only for migration.
+
+/**
+ * Get the path to the global file-per-entry store directory (v1.10.0 layout).
+ * Sits alongside the legacy `data.json` inside `getDataDirectory()` so the
+ * existing sibling files (`config.json`, `audit.jsonl`, `telemetry.jsonl`,
+ * `miss-paths.jsonl`, `.backups/`) stay where they are.
+ */
+export function getGlobalStoreDirPath(): string {
+  return path.join(getDataDirectory(), 'store');
+}
+
+// Cached project store directory path (null = not searched yet, '' = not found)
+let projectStoreDirCache: string | null = null;
+
+/**
+ * Walk up from cwd (or the programmatic override) to find a `.codexcli/`
+ * directory, which is the v1.10.0 project store. Returns the absolute path
+ * if found, null otherwise.
+ *
+ * Resolution order mirrors `findProjectFile()`:
+ *   1. CODEX_NO_PROJECT env var → disabled
+ *   2. CODEX_PROJECT env var → explicit path, fails closed if missing
+ *   3. setProjectRootOverride() value (MCP client roots, launcher hints)
+ *   4. process.cwd() walk-up
+ *
+ * Unlike `findProjectFile()`, this function *only* matches a directory
+ * named `.codexcli` — it will not fall back to the legacy `.codexcli.json`
+ * file. Callers that need to handle both old and new formats should check
+ * `findProjectStoreDir()` first and fall back to `findProjectFile()`.
+ */
+export function findProjectStoreDir(): string | null {
+  if (projectStoreDirCache !== null) {
+    return projectStoreDirCache === '' ? null : projectStoreDirCache;
+  }
+
+  if (process.env.CODEX_NO_PROJECT) {
+    projectStoreDirCache = '';
+    return null;
+  }
+
+  // Explicit env var override — path to a `.codexcli` directory or its parent.
+  const envPath = process.env.CODEX_PROJECT;
+  if (envPath) {
+    const resolved = path.resolve(envPath);
+    let candidate = resolved;
+    try {
+      if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()) {
+        // If the resolved path IS `.codexcli`, use it directly; otherwise
+        // look for `.codexcli` inside it.
+        if (path.basename(resolved) !== '.codexcli') {
+          candidate = path.join(resolved, '.codexcli');
+        }
+      }
+    } catch {
+      // fall through; isDirectory check below will handle it
+    }
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      projectStoreDirCache = candidate;
+      return candidate;
+    }
+    // CODEX_PROJECT set but didn't resolve to a directory — fail closed,
+    // matching findProjectFile()'s behavior.
+    projectStoreDirCache = '';
+    return null;
+  }
+
+  const globalDir = getDataDirectory();
+  let dir = projectRootOverride ?? process.cwd();
+  const root = path.parse(dir).root;
+
+  while (true) {
+    // Don't match anything inside the global data directory.
+    if (path.resolve(dir) === path.resolve(globalDir)) {
+      projectStoreDirCache = '';
+      return null;
+    }
+
+    const candidate = path.join(dir, '.codexcli');
+    try {
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+        projectStoreDirCache = candidate;
+        return candidate;
+      }
+    } catch {
+      // stat failed — ignore and keep walking
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir || dir === root) {
+      projectStoreDirCache = '';
+      return null;
+    }
+    dir = parent;
+  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     env: { CODEX_DATA_DIR: path.join(os.tmpdir(), 'codexcli-vitest') },
     root: './src',
     include: ['**/__tests__/**/*.ts', '**/*.{test,spec}.ts'],
+    exclude: ['**/__tests__/helpers/**'],
     coverage: {
       provider: 'v8',
       reportsDirectory: '../coverage',


### PR DESCRIPTION
Six issues flagged in review of the file-per-entry store PR: prototype pollution (CodeQL), EISDIR crash in `ccli lint`, silent data loss on migration failure, path traversal via user-controlled keys, non-atomic migration, and `ccli init` EEXIST crash.

## Changes

### Security
- **Prototype pollution** (`readStoreState.ts`): `setNested` now uses explicit `=== '__proto__'`/`constructor`/`prototype` guards on every segment and `Object.create(null)` for intermediate objects. CodeQL: 0 alerts.
- **Key validation / path traversal** (`directoryStore.ts`): Added `isValidEntryKey()` — rejects keys with `/`, `\`, `..`, leading `_`, empty segments, and prototype-polluting names. Applied in `entryFilePath` (+ cross-platform `path.relative()` defense-in-depth), `scanAndSync`, and `migrateFileToDirectory`.

```ts
// Before: raw key used directly as filename component
export function entryFilePath(dir: string, key: string): string {
  return path.join(dir, key + ENTRY_FILE_SUFFIX);  // '../escape' works
}

// After: validated + path-escaped
export function entryFilePath(dir: string, key: string): string {
  if (!isValidEntryKey(key)) throw new Error(`Invalid store key: ${JSON.stringify(key)}`);
  const relative = path.relative(path.resolve(dir), path.resolve(filePath));
  if (relative.startsWith('..') || path.isAbsolute(relative)) throw ...;
  return filePath;
}
```

### Atomicity
- **Atomic migration** (`directoryStore.ts`): `migrateFileToDirectory` now writes to a `.tmp` sibling and renames it in one shot. Previously, a crash mid-loop left a partially-written directory that was treated as authoritative on next startup, silently truncating the store.

### Correctness
- **EISDIR in `ccli lint`** (`lint.ts`): `loadCustomSchema` short-circuits when `findProjectFile()` returns a `.codexcli/` directory, preventing a crash on every `ccli lint` call in v1.10.0 projects.
- **Migration failure visibility** (`store.ts`): If unified→directory migration fails and the store directory wasn't created, emit `console.warn` instead of silently presenting an empty store.
- **`ccli init` EEXIST** (`data-management.ts`): Single `statSync` call; if target exists but isn't a directory, print a descriptive error (`file`/`symlink`/`other`) and exit cleanly.

### Interface cleanup
- **`ScopedStore.prime()` removed** from interface and `createDirectoryStore` — it was a no-op that never shipped a real caller. CHANGELOG updated to match.

### Misc
- `.codexcli/` and `.codexcli.json.backup` added to `.gitignore` to prevent migration artifacts from leaking into commits.