### PR TITLE
fix(store): tighten epoch validation, README no-clobber atomicity, and test mtime determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **File-per-entry store: torn reads during concurrent writes** — `load()` could observe a partially-committed `save()` when another process was mid-write (some entries updated, others not), with no way to detect it. The store now uses a seqlock-style commit epoch in a new `_epoch.json` sidecar: even values mean "stable," odd means "writer mid-commit." `save()` bumps the epoch to odd before touching any files and to the next even value after all writes complete, both under the existing directory lock. `load()` snapshots the epoch before and after its scan and retries (bounded to 3 attempts with 1–8 ms backoff) if it sees a mismatch or an odd "before" value. Missing or bogus `_epoch.json` reads as 0, so legacy directories and fresh installs transition cleanly through the first save.
+- **File-per-entry store: migration race on pristine installs** — `migrateFileToDirectory` ran without a lock. Two processes starting simultaneously on a pristine install could both enter the migration path and race. The migration now runs inside `withFileLock(newDirPath, …)`, reusing the same lock key as the steady-state store, so migrations and normal saves are mutually exclusive. The loser waits, observes the new directory, and returns `already-present`. Migration also seeds `_epoch.json` at 0 inside its tmp directory before the atomic rename, so readers see a coherent epoch from the instant the store directory exists.
+
+### Added
+
+- **`_README.md` hand-edit warning sidecar** — file-per-entry layout's big UX win is that per-entry files are browsable in a file manager, but that also invites developers to open one and tweak it directly (which desyncs per-entry metadata and breaks staleness signals — see `conventions.editSurface`). The store now seeds a `_README.md` on first `save()` and during migration with an in-context nudge pointing at the supported edit paths. Idempotent: a user-customized `_README.md` is never overwritten.
+
+### Changed
+
+- **File-per-entry store: sidecar mtime tracking** — `_aliases.json` and `_confirm.json` were re-read and JSON-parsed on every `scanAndSync()`, even when nothing had changed. They now go through the same mtime-cached path as entry files: a stat-first refresh skips the re-read when mtime matches. Missing sidecars cache as an `-1` sentinel so they're detected the moment they appear on disk. `load()` now returns defensive shallow copies of the cached sidecar maps so callers that mutate-then-save (`setAlias` and friends) can't accidentally pollute the cache.
+
 ## [1.10.0] - 2026-04-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "codexcli",
-	"version": "1.9.2",
+	"version": "1.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "codexcli",
-			"version": "1.9.2",
+			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -703,6 +703,7 @@ describe('sidecar mtime cache', () => {
       aliasesPath,
       JSON.stringify({ y: 'a' }, null, 2)
     );
+    // +1000 ms ensures the bump is visible even on filesystems with 1-second mtime granularity.
     const newerMtime = new Date(previousStat.mtimeMs + 1000);
     fs.utimesSync(aliasesPath, newerMtime, newerMtime);
 

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -473,3 +473,176 @@ describe('getStoreLockKey', () => {
     expect(getStoreLockKey('/a/b/.codexcli')).toBe('/a/b/.codexcli');
   });
 });
+
+// ── Epoch seqlock (torn-read protection) ──────────────────────────────
+
+function readEpochFile(dir: string): number {
+  const raw = fs.readFileSync(path.join(dir, '_epoch.json'), 'utf8');
+  return (JSON.parse(raw) as { epoch: number }).epoch;
+}
+
+describe('epoch seqlock', () => {
+  it('first save bumps epoch from 0 to 2 (stable even)', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+
+    expect(readEpochFile(dir)).toBe(2);
+  });
+
+  it('subsequent saves advance epoch by 2 each time', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+    expect(readEpochFile(dir)).toBe(2);
+
+    store.save({ entries: { a: '2' }, aliases: {}, confirm: {} });
+    expect(readEpochFile(dir)).toBe(4);
+
+    store.save({ entries: { a: '3' }, aliases: {}, confirm: {} });
+    expect(readEpochFile(dir)).toBe(6);
+  });
+
+  it('load() tolerates a missing epoch file (legacy dirs without _epoch.json)', () => {
+    // Simulate a store directory that was created before the epoch file existed.
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(
+      path.join(dir, 'only.json'),
+      JSON.stringify({ value: 'preserved' })
+    );
+
+    const store = makeStore(dir);
+    const data = store.load();
+    expect(data.entries).toEqual({ only: 'preserved' });
+  });
+
+  it('load() recovers from a bogus/garbled epoch file', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, '_epoch.json'), 'not json');
+    fs.writeFileSync(
+      path.join(dir, 'x.json'),
+      JSON.stringify({ value: 'still readable' })
+    );
+
+    const store = makeStore(dir);
+    const data = store.load();
+    expect(data.entries).toEqual({ x: 'still readable' });
+  });
+
+  it('load() returns a consistent snapshot when epoch is even and unchanged across scan', () => {
+    // This is the happy path: no concurrent writer, load() completes on attempt 0.
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({
+      entries: { a: '1', b: '2' },
+      aliases: { x: 'a' },
+      confirm: { a: true },
+      _meta: { a: 100, b: 200 },
+    });
+
+    const fresh = makeStore(dir);
+    const loaded = fresh.load();
+
+    expect(loaded.entries).toEqual({ a: '1', b: '2' });
+    expect(loaded.aliases).toEqual({ x: 'a' });
+    expect(loaded.confirm).toEqual({ a: true });
+  });
+
+  it('load() detects an odd (in-progress) epoch and still returns best-effort data', () => {
+    // Simulate a crashed writer that left an odd epoch on disk. load() should
+    // exhaust retries, log via debug, and return whatever it can scan —
+    // rather than hanging or throwing.
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+
+    // Stamp an odd epoch to simulate a crashed mid-commit writer.
+    fs.writeFileSync(path.join(dir, '_epoch.json'), JSON.stringify({ epoch: 7 }) + '\n');
+
+    const fresh = makeStore(dir);
+    const loaded = fresh.load();
+
+    // We should still get the entry data that was durably written.
+    expect(loaded.entries).toEqual({ a: '1' });
+  });
+});
+
+// ── Migration lock (concurrent first-run) ──────────────────────────────
+
+describe('migrateFileToDirectory concurrency', () => {
+  it('is safe to call twice in a row (second call is already-present)', () => {
+    // Sequential calls exercise the same idempotency guarantee the lock
+    // provides for concurrent callers: the winner migrates, the loser
+    // finds the directory already populated.
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: { a: '1', b: '2' },
+      aliases: {},
+      confirm: {},
+      _meta: { a: 100, b: 200 },
+    }));
+
+    const first = migrateFileToDirectory(oldFile, newDir);
+    expect(first.status).toBe('migrated');
+    expect(first.entryCount).toBe(2);
+
+    // The "lingering old file" cleanup branch runs if the old file reappears,
+    // so put it back to verify the second call takes the already-present path.
+    fs.writeFileSync(oldFile, JSON.stringify({ entries: { a: '1' } }));
+    const second = migrateFileToDirectory(oldFile, newDir);
+    expect(second.status).toBe('already-present');
+    // Old file was renamed to .backup as cleanup.
+    expect(fs.existsSync(oldFile)).toBe(false);
+  });
+
+  it('seeds _epoch.json at 0 during migration', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: { a: '1' },
+      aliases: {},
+      confirm: {},
+    }));
+
+    migrateFileToDirectory(oldFile, newDir);
+
+    expect(fs.existsSync(path.join(newDir, '_epoch.json'))).toBe(true);
+    expect(readEpochFile(newDir)).toBe(0);
+  });
+
+  it('first save after migration bumps epoch to 2', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: { a: '1' },
+      aliases: {},
+      confirm: {},
+    }));
+
+    migrateFileToDirectory(oldFile, newDir);
+    const store = makeStore(newDir);
+    store.save({
+      entries: { a: '1', b: 'new' },
+      aliases: {},
+      confirm: {},
+    });
+
+    expect(readEpochFile(newDir)).toBe(2);
+  });
+
+  it('removes the tmp dir on a throwing migration, leaving no partial state', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    // Malformed JSON causes migrateFileToDirectory to throw before the tmp→final rename.
+    fs.writeFileSync(oldFile, '{corrupt');
+
+    expect(() => migrateFileToDirectory(oldFile, newDir)).toThrow();
+    expect(fs.existsSync(newDir)).toBe(false);
+    expect(fs.existsSync(newDir + '.tmp')).toBe(false);
+  });
+});

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -646,3 +646,165 @@ describe('migrateFileToDirectory concurrency', () => {
     expect(fs.existsSync(newDir + '.tmp')).toBe(false);
   });
 });
+
+// ── Sidecar mtime tracking ─────────────────────────────────────────────
+
+describe('sidecar mtime cache', () => {
+  it('does not re-read _aliases.json when its mtime is unchanged', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({
+      entries: { a: '1' },
+      aliases: { x: 'a' },
+      confirm: {},
+    });
+
+    // Prime the cache.
+    store.load();
+
+    // Spy on fs.readFileSync after priming, counting reads of the aliases sidecar.
+    const readFileSync = fs.readFileSync;
+    let aliasReads = 0;
+    const aliasPath = path.join(dir, '_aliases.json');
+    // @ts-expect-error -- intentional test-only monkey patch
+    fs.readFileSync = function spyRead(p: fs.PathOrFileDescriptor, ...rest: unknown[]) {
+      if (typeof p === 'string' && path.resolve(p) === path.resolve(aliasPath)) {
+        aliasReads++;
+      }
+      // @ts-expect-error -- spread through to the real impl
+      return readFileSync.call(this, p, ...rest);
+    };
+    try {
+      // Several loads with no disk changes → sidecar should not be re-read.
+      store.load();
+      store.load();
+      store.load();
+    } finally {
+      fs.readFileSync = readFileSync;
+    }
+
+    expect(aliasReads).toBe(0);
+  });
+
+  it('re-reads _aliases.json when its mtime changes (external write)', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({
+      entries: { a: '1' },
+      aliases: { x: 'a' },
+      confirm: {},
+    });
+    store.load();  // prime
+
+    // Simulate an external rewrite with a newer mtime.
+    // Spin briefly so the mtime actually advances on coarse-grained filesystems.
+    const target = Date.now() + 20;
+    while (Date.now() < target) { /* spin */ }
+    fs.writeFileSync(
+      path.join(dir, '_aliases.json'),
+      JSON.stringify({ y: 'a' }, null, 2)
+    );
+
+    const reloaded = store.load();
+    expect(reloaded.aliases).toEqual({ y: 'a' });
+  });
+
+  it('load() returns defensive copies of sidecars so caller-mutation does not pollute the cache', () => {
+    // Regression: setAlias and friends call loadAliasMap, mutate the returned
+    // object in place, then call saveAliasMap with the mutated reference. If
+    // load() handed out the cached object by reference, the dirty-check in
+    // save() would see "cache === caller's data" via shallowEquals and skip
+    // the write — silently dropping the alias.
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({
+      entries: { a: '1' },
+      aliases: { existing: 'a' },
+      confirm: {},
+    });
+
+    const first = store.load();
+    // Simulate a caller mutating loadAliasMap's return value.
+    (first.aliases as Record<string, string>)['added'] = 'a';
+
+    // Now save the mutated data. If the cache was shared by reference, the
+    // dirty-check would conclude "no change" and skip writing the new alias.
+    store.save(first);
+
+    // Fresh store reading straight from disk — the added alias must be there.
+    const fresh = makeStore(dir);
+    const reloaded = fresh.load();
+    expect(reloaded.aliases).toEqual({ existing: 'a', added: 'a' });
+  });
+
+  it('picks up a sidecar that appears after initial load (missing → present)', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, 'x.json'), JSON.stringify({ value: 'v' }));
+
+    const store = makeStore(dir);
+    let data = store.load();
+    expect(data.aliases).toEqual({});
+
+    // Write a sidecar that wasn't there on the first scan.
+    fs.writeFileSync(path.join(dir, '_aliases.json'), JSON.stringify({ z: 'x' }));
+
+    data = store.load();
+    expect(data.aliases).toEqual({ z: 'x' });
+  });
+});
+
+// ── Hand-edit warning README ───────────────────────────────────────────
+
+describe('_README.md hand-edit nudge', () => {
+  it('save() writes _README.md on first invocation', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+
+    expect(fs.existsSync(path.join(dir, '_README.md'))).toBe(false);
+
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+
+    const readmePath = path.join(dir, '_README.md');
+    expect(fs.existsSync(readmePath)).toBe(true);
+    const contents = fs.readFileSync(readmePath, 'utf8');
+    expect(contents).toContain('do not hand-edit');
+  });
+
+  it('does not overwrite a user-customized _README.md', () => {
+    const dir = path.join(tmpRoot, 'store');
+    fs.mkdirSync(dir);
+    const custom = '# My custom store README\n';
+    fs.writeFileSync(path.join(dir, '_README.md'), custom);
+
+    const store = makeStore(dir);
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+
+    const contents = fs.readFileSync(path.join(dir, '_README.md'), 'utf8');
+    expect(contents).toBe(custom);
+  });
+
+  it('_README.md is not picked up as an entry file', () => {
+    const dir = path.join(tmpRoot, 'store');
+    const store = makeStore(dir);
+    store.save({ entries: { a: '1' }, aliases: {}, confirm: {} });
+
+    const data = store.load();
+    // Only the real entry "a" is visible.
+    expect(data.entries).toEqual({ a: '1' });
+  });
+
+  it('migration seeds _README.md alongside the migrated entries', () => {
+    const oldFile = path.join(tmpRoot, '.codexcli.json');
+    const newDir = path.join(tmpRoot, '.codexcli');
+    fs.writeFileSync(oldFile, JSON.stringify({
+      entries: { a: '1' },
+      aliases: {},
+      confirm: {},
+    }));
+
+    migrateFileToDirectory(oldFile, newDir);
+
+    expect(fs.existsSync(path.join(newDir, '_README.md'))).toBe(true);
+  });
+});

--- a/src/__tests__/directoryStore.test.ts
+++ b/src/__tests__/directoryStore.test.ts
@@ -696,14 +696,15 @@ describe('sidecar mtime cache', () => {
     });
     store.load();  // prime
 
-    // Simulate an external rewrite with a newer mtime.
-    // Spin briefly so the mtime actually advances on coarse-grained filesystems.
-    const target = Date.now() + 20;
-    while (Date.now() < target) { /* spin */ }
+    // Simulate an external rewrite with a newer mtime using utimesSync for determinism.
+    const aliasesPath = path.join(dir, '_aliases.json');
+    const previousStat = fs.statSync(aliasesPath);
     fs.writeFileSync(
-      path.join(dir, '_aliases.json'),
+      aliasesPath,
       JSON.stringify({ y: 'a' }, null, 2)
     );
+    const newerMtime = new Date(previousStat.mtimeMs + 1000);
+    fs.utimesSync(aliasesPath, newerMtime, newerMtime);
 
     const reloaded = store.load();
     expect(reloaded.aliases).toEqual({ y: 'a' });

--- a/src/__tests__/fuzz.test.ts
+++ b/src/__tests__/fuzz.test.ts
@@ -32,6 +32,41 @@ function randomKey(depth: number = Math.ceil(Math.random() * 4)): string {
   return segments.join('.');
 }
 
+/**
+ * Generate a set of random dotted keys in which no key is a prefix of
+ * another. This is the invariant `expandFlatKeys` + `flattenObject`
+ * round-trip requires — if both `a.b` and `a.b.c` appear in the same
+ * flat map, one of them has to lose when expanded (you can't have `a.b`
+ * be both a string and an object), so the round-trip is undefined.
+ *
+ * Candidates are generated one at a time and accepted only if they
+ * neither extend nor are extended by an already-accepted key. Bounded
+ * retries keep the loop from spinning on a pathological RNG streak;
+ * `requested` is a target, not a hard guarantee, and the returned array
+ * is always non-empty.
+ */
+function randomPrefixFreeKeys(requested: number): string[] {
+  const accepted: string[] = [];
+  const maxAttempts = requested * 20;
+  for (let attempt = 0; attempt < maxAttempts && accepted.length < requested; attempt++) {
+    const candidate = randomKey();
+    if (!candidate) continue;
+    let collides = false;
+    for (const existing of accepted) {
+      if (candidate === existing ||
+          candidate.startsWith(existing + '.') ||
+          existing.startsWith(candidate + '.')) {
+        collides = true;
+        break;
+      }
+    }
+    if (!collides) accepted.push(candidate);
+  }
+  // Guarantee at least one key so the enclosing test loop always has work.
+  if (accepted.length === 0) accepted.push('fallback');
+  return accepted;
+}
+
 function randomValue(): string {
   const types = ['short', 'long', 'unicode', 'special', 'empty'];
   const type = types[Math.floor(Math.random() * types.length)];
@@ -132,11 +167,17 @@ describe('fuzz: flattenObject ↔ expandFlatKeys round-trip', () => {
   });
 
   it('expand then flatten returns same flat map (50 trials)', () => {
+    // Input must be prefix-free: the `expand → flatten` round-trip is only
+    // defined when no key in the flat map is a prefix of another. If both
+    // `a.b` and `a.b.c` appear, `expandFlatKeys` has to pick one to win
+    // (the other's value is lost), so the round-trip is undefined. Using
+    // raw `randomKey()` here produced ~40% flakes whenever the RNG
+    // happened to generate colliding keys; see `randomPrefixFreeKeys`.
     for (let trial = 0; trial < 50; trial++) {
       const flat: Record<string, string> = {};
       const numKeys = 3 + Math.floor(Math.random() * 8);
-      for (let i = 0; i < numKeys; i++) {
-        flat[randomKey()] = randomValue();
+      for (const key of randomPrefixFreeKeys(numKeys)) {
+        flat[key] = randomValue();
       }
 
       const expanded = expandFlatKeys(flat);

--- a/src/store.ts
+++ b/src/store.ts
@@ -66,6 +66,18 @@ function getGlobalStore(): ScopedStore {
       //      and the pre-rename data.json format. Produces a unified .codexcli/data.json.
       //   2. Unified → directory (v1.10.0): converts the unified file to the file-per-entry
       //      layout at ~/.codexcli/store/. This is the new canonical layout.
+      //
+      // Ensure the parent directory (~/.codexcli/) exists before the
+      // directory migration runs, so its file lock (placed at
+      // `<storeDir>.lock`, a sibling of the store dir) can be created.
+      // Without this, pristine installs would fall through to the
+      // unlocked fallback in withFileLock — still safe on a truly-fresh
+      // system, but we prefer locked from the start.
+      try {
+        ensureDataDirectoryExists();
+      } catch (err) {
+        debug(`Failed to ensure global data directory before migration: ${String(err)}`);
+      }
       try {
         migrateToUnifiedFile();
       } catch (err) {

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -46,12 +46,51 @@ interface CachedEntry {
   mtimeMs: number;
 }
 
+/**
+ * Cached state of one sidecar file (_aliases.json, _confirm.json).
+ * `mtimeMs` of `-1` means "observed as missing" — used so that a later
+ * fs.stat of a real mtime compares unequal and triggers a re-read.
+ */
+interface CachedSidecar<T> {
+  data: T;
+  mtimeMs: number;
+}
+
 // ── File layout helpers ────────────────────────────────────────────────
 
 const ALIASES_FILE = '_aliases.json';
 const CONFIRM_FILE = '_confirm.json';
 const EPOCH_FILE = '_epoch.json';
+const README_FILE = '_README.md';
 const ENTRY_FILE_SUFFIX = '.json';
+
+/**
+ * Hand-edit warning written to `<store>/_README.md` on store creation. The
+ * `_` prefix means isEntryFilename ignores it; it exists purely as an
+ * in-context nudge for developers browsing the directory who might
+ * otherwise be tempted to open an entry file and tweak it. See the codex
+ * entry `conventions.editSurface` for the rationale.
+ */
+const README_CONTENT = `# codexCLI store — do not hand-edit
+
+This directory is managed by codexCLI. Each \`*.json\` file is a single
+store entry written through the CLI or MCP tools. Sidecar files starting
+with \`_\` (this README, \`_aliases.json\`, \`_confirm.json\`, \`_epoch.json\`)
+are internal bookkeeping.
+
+**Edit via one of:**
+
+- \`ccli set <key> <value>\` (and the rest of the CLI)
+- The codexCLI MCP tools (\`codex_set\`, \`codex_get\`, etc.)
+- A future UI
+
+Direct edits to these files desync per-entry metadata (created/updated
+timestamps, future verified/agent fields) and silently break staleness
+signals. The wrapper format \`{ value, meta }\` assumes only the official
+tools touch it.
+
+If you need to bulk-import or restructure, do it through the CLI.
+`;
 
 /**
  * Maximum number of retries for the seqlock loop in load(). In practice,
@@ -221,6 +260,26 @@ function writeEpoch(dir: string, epoch: number): void {
   atomicWriteFileSync(path.join(dir, EPOCH_FILE), JSON.stringify({ epoch }) + '\n');
 }
 
+/**
+ * Write the hand-edit warning README to the store directory if it doesn't
+ * already exist. Idempotent and best-effort: a failure to write (read-only
+ * filesystem, permissions) is logged via debug and swallowed so the store
+ * itself keeps working.
+ *
+ * We check with existsSync rather than overwriting unconditionally so a
+ * user who customized the wording (or replaced it with a symlink) isn't
+ * stomped on every save.
+ */
+function ensureReadme(dir: string): void {
+  const readmePath = path.join(dir, README_FILE);
+  try {
+    if (fs.existsSync(readmePath)) return;
+    atomicWriteFileSync(readmePath, README_CONTENT);
+  } catch (err) {
+    debug(`Failed to write ${README_FILE} in ${dir}: ${String(err)}`);
+  }
+}
+
 // ── Equality helpers ───────────────────────────────────────────────────
 
 /**
@@ -270,14 +329,45 @@ export function createDirectoryStore(
   // Per-entry cache, keyed by dotted key. Each entry records its file mtime
   // so we can detect external writes between load() calls.
   const entryCache = new Map<string, CachedEntry>();
-  // Sidecar caches — small, not mtime-tracked, refreshed on every scanAndSync().
-  let aliasesCache: Record<string, string> | null = null;
-  let confirmCache: Record<string, true> | null = null;
+  // Sidecar caches — mtime-tracked so scanAndSync() can skip the re-read when
+  // nothing changed. A cached sentinel mtime of `-1` means "observed as
+  // missing"; any real fs.stat mtime compares unequal, so we'll pick up a
+  // sidecar that appears later without a stale-read hazard.
+  let aliasesCache: CachedSidecar<Record<string, string>> | null = null;
+  let confirmCache: CachedSidecar<Record<string, true>> | null = null;
 
   function clear(): void {
     entryCache.clear();
     aliasesCache = null;
     confirmCache = null;
+  }
+
+  /**
+   * Stat a sidecar file and return either its current data (cached or
+   * re-read) or an empty-object fallback if it's missing. Updates the
+   * passed-in cache slot in place by returning the new CachedSidecar;
+   * callers assign the result back.
+   */
+  function refreshSidecar<T extends Record<string, unknown>>(
+    filePath: string,
+    cached: CachedSidecar<T> | null
+  ): CachedSidecar<T> {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch (err) {
+      if (isENOENT(err)) {
+        // File missing. If we already had a "missing" sentinel, keep it;
+        // otherwise install one so future scans can detect a new sidecar.
+        return cached?.mtimeMs === -1 ? cached : { data: {} as T, mtimeMs: -1 };
+      }
+      throw err;
+    }
+    if (cached?.mtimeMs === stat.mtimeMs) {
+      return cached;
+    }
+    const data = readSidecar<T>(filePath);
+    return { data, mtimeMs: stat.mtimeMs };
   }
 
   /**
@@ -294,8 +384,8 @@ export function createDirectoryStore(
     } catch (err) {
       if (isENOENT(err)) {
         entryCache.clear();
-        aliasesCache = {};
-        confirmCache = {};
+        aliasesCache = { data: {}, mtimeMs: -1 };
+        confirmCache = { data: {}, mtimeMs: -1 };
         return;
       }
       throw err;
@@ -337,9 +427,17 @@ export function createDirectoryStore(
       if (!seen.has(key)) entryCache.delete(key);
     }
 
-    // Refresh sidecar caches. Small files, re-read on every scan.
-    aliasesCache = readSidecar<Record<string, string>>(path.join(dir, ALIASES_FILE));
-    confirmCache = readSidecar<Record<string, true>>(path.join(dir, CONFIRM_FILE));
+    // Refresh sidecar caches. refreshSidecar stats first and re-parses only
+    // if the mtime changed, so an unchanged sidecar costs a single stat()
+    // instead of a stat + read + JSON.parse.
+    aliasesCache = refreshSidecar<Record<string, string>>(
+      path.join(dir, ALIASES_FILE),
+      aliasesCache
+    );
+    confirmCache = refreshSidecar<Record<string, true>>(
+      path.join(dir, CONFIRM_FILE),
+      confirmCache
+    );
   }
 
   function load(): UnifiedData {
@@ -387,10 +485,18 @@ export function createDirectoryStore(
     }
     const entries = expandFlatKeys(flat) as CodexData;
 
+    // Defensive shallow copies: callers (e.g. setAlias) load the map, mutate
+    // it in place, then call save with the mutated reference. Under the old
+    // (non-mtime-cached) sidecar path, this was safe because every scanAndSync
+    // reassigned `aliasesCache` to a fresh JSON.parse result — the caller's
+    // mutated copy was no longer the cache. Now that we reuse the cache
+    // across scans when mtime is unchanged, we have to hand out copies so
+    // caller mutation doesn't silently pollute the cache (which would make
+    // the dirty-check in save() return "no change" and skip the write).
     const result: UnifiedData = {
       entries,
-      aliases: aliasesCache ?? {},
-      confirm: confirmCache ?? {},
+      aliases: { ...(aliasesCache?.data ?? {}) },
+      confirm: { ...(confirmCache?.data ?? {}) },
     };
     if (Object.keys(meta).length > 0) {
       result._meta = meta;
@@ -401,6 +507,7 @@ export function createDirectoryStore(
   function save(data: UnifiedData): void {
     const dir = getDirPath();
     ensureDir();
+    ensureReadme(dir);
 
     withFileLock(getStoreLockKey(dir), () => {
       // 0. Begin commit: bump epoch to the next odd value. Readers that
@@ -460,20 +567,17 @@ export function createDirectoryStore(
         entryCache.set(key, { wrapper, mtimeMs });
       }
 
-      // 5. Sidecars — rewrite only if changed.
-      if (!aliasesCache || !shallowEquals(aliasesCache, data.aliases)) {
-        atomicWriteFileSync(
-          path.join(dir, ALIASES_FILE),
-          serializeSidecar(data.aliases)
-        );
-        aliasesCache = { ...data.aliases };
+      // 5. Sidecars — rewrite only if changed. After a write, pick up the
+      //    new mtime from statSync so future scans can skip the re-read.
+      if (!aliasesCache || aliasesCache.mtimeMs === -1 || !shallowEquals(aliasesCache.data, data.aliases)) {
+        const aliasPath = path.join(dir, ALIASES_FILE);
+        atomicWriteFileSync(aliasPath, serializeSidecar(data.aliases));
+        aliasesCache = { data: { ...data.aliases }, mtimeMs: fs.statSync(aliasPath).mtimeMs };
       }
-      if (!confirmCache || !shallowEquals(confirmCache, data.confirm)) {
-        atomicWriteFileSync(
-          path.join(dir, CONFIRM_FILE),
-          serializeSidecar(data.confirm)
-        );
-        confirmCache = { ...data.confirm };
+      if (!confirmCache || confirmCache.mtimeMs === -1 || !shallowEquals(confirmCache.data, data.confirm)) {
+        const confirmPath = path.join(dir, CONFIRM_FILE);
+        atomicWriteFileSync(confirmPath, serializeSidecar(data.confirm));
+        confirmCache = { data: { ...data.confirm }, mtimeMs: fs.statSync(confirmPath).mtimeMs };
       }
 
       // 6. End commit: bump epoch to the next even value. Any reader that
@@ -627,6 +731,10 @@ function migrateFileToDirectoryLocked(
     // will bump it to 1 → 2, and readers running concurrently with that
     // first save will correctly detect the in-progress commit.
     writeEpoch(tmpDirPath, 0);
+
+    // Seed the hand-edit warning README alongside the data files, so the
+    // migrated directory gets the same nudge a fresh store does.
+    ensureReadme(tmpDirPath);
 
     // Atomic swap: rename the fully-written tmp directory to the final path.
     fs.renameSync(tmpDirPath, newDirPath);

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -246,7 +246,9 @@ function readEpoch(dir: string): number {
   try {
     const raw = fs.readFileSync(path.join(dir, EPOCH_FILE), 'utf8');
     const parsed = JSON.parse(raw) as { epoch?: unknown };
-    if (typeof parsed.epoch === 'number' && Number.isFinite(parsed.epoch)) {
+    if (typeof parsed.epoch === 'number'
+      && Number.isSafeInteger(parsed.epoch)
+      && parsed.epoch >= 0) {
       return parsed.epoch;
     }
     return 0;
@@ -266,16 +268,15 @@ function writeEpoch(dir: string, epoch: number): void {
  * filesystem, permissions) is logged via debug and swallowed so the store
  * itself keeps working.
  *
- * We check with existsSync rather than overwriting unconditionally so a
- * user who customized the wording (or replaced it with a symlink) isn't
- * stomped on every save.
+ * Use an atomic no-clobber create so a README that appears concurrently
+ * (for example, a user-customized file) is preserved rather than replaced.
  */
 function ensureReadme(dir: string): void {
   const readmePath = path.join(dir, README_FILE);
   try {
-    if (fs.existsSync(readmePath)) return;
-    atomicWriteFileSync(readmePath, README_CONTENT);
+    fs.writeFileSync(readmePath, README_CONTENT, { flag: 'wx' });
   } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return;
     debug(`Failed to write ${README_FILE} in ${dir}: ${String(err)}`);
   }
 }

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -50,7 +50,22 @@ interface CachedEntry {
 
 const ALIASES_FILE = '_aliases.json';
 const CONFIRM_FILE = '_confirm.json';
+const EPOCH_FILE = '_epoch.json';
 const ENTRY_FILE_SUFFIX = '.json';
+
+/**
+ * Maximum number of retries for the seqlock loop in load(). In practice,
+ * writes are short (sub-millisecond for small saves), so a handful of retries
+ * is more than enough to ride out even pathologically overlapping writes.
+ * After exhausting retries we return a best-effort snapshot and log via debug.
+ */
+const MAX_LOAD_RETRIES = 3;
+
+/**
+ * Small shared buffer for Atomics.wait()-based sleeps during the load()
+ * retry loop. Reused across all store instances to avoid per-call allocation.
+ */
+const _loadRetrySleep = new Int32Array(new SharedArrayBuffer(4));
 
 /** True if a filename in the store directory represents an entry (not a sidecar). */
 function isEntryFilename(name: string): boolean {
@@ -162,6 +177,48 @@ function isENOENT(err: unknown): boolean {
     'code' in err &&
     (err as { code: string }).code === 'ENOENT'
   );
+}
+
+// ── Epoch (seqlock for torn-read detection) ───────────────────────────
+//
+// The store uses a seqlock pattern to let readers (load()) detect that
+// they overlapped a writer (save()) without taking the writer lock.
+//
+// Convention:
+//   - Even epoch  = stable state, no writer in progress.
+//   - Odd epoch   = writer mid-commit. Readers must not trust the on-disk
+//                   state while they observe an odd epoch.
+//
+// save() bumps epoch to odd before touching any files, then to the next
+// even value after all writes complete — both bumps happen under the
+// directory lock. Readers snapshot the epoch before and after scanning;
+// a match on an even value guarantees no writer committed during the scan.
+//
+// The epoch file is `_epoch.json` at the store directory root. The `_`
+// prefix means `isEntryFilename` already excludes it from entry scans.
+
+/**
+ * Read the commit epoch from `_epoch.json`. Returns 0 when the file is
+ * missing, unparseable, or shaped wrong — these are all treated as "no
+ * writer has ever run," which is the correct initial state (the first
+ * save will bump through 1 → 2 and establish the invariant).
+ */
+function readEpoch(dir: string): number {
+  try {
+    const raw = fs.readFileSync(path.join(dir, EPOCH_FILE), 'utf8');
+    const parsed = JSON.parse(raw) as { epoch?: unknown };
+    if (typeof parsed.epoch === 'number' && Number.isFinite(parsed.epoch)) {
+      return parsed.epoch;
+    }
+    return 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Atomically write the commit epoch to `_epoch.json`. */
+function writeEpoch(dir: string, epoch: number): void {
+  atomicWriteFileSync(path.join(dir, EPOCH_FILE), JSON.stringify({ epoch }) + '\n');
 }
 
 // ── Equality helpers ───────────────────────────────────────────────────
@@ -286,7 +343,38 @@ export function createDirectoryStore(
   }
 
   function load(): UnifiedData {
-    scanAndSync();
+    const dir = getDirPath();
+
+    // Seqlock retry: snapshot the epoch before scanning, scan, then re-read
+    // the epoch. If a writer committed during the scan (or is mid-commit
+    // when we start), the epochs will differ or the "before" read will be
+    // odd — retry in either case. Bounded to MAX_LOAD_RETRIES so we never
+    // spin indefinitely under heavy write contention.
+    for (let attempt = 0; attempt <= MAX_LOAD_RETRIES; attempt++) {
+      const before = readEpoch(dir);
+      if (before % 2 !== 0) {
+        // Writer is mid-commit. Back off briefly and retry.
+        if (attempt < MAX_LOAD_RETRIES) {
+          Atomics.wait(_loadRetrySleep, 0, 0, 1 << attempt); // 1ms, 2ms, 4ms, 8ms
+          continue;
+        }
+        debug(
+          `Store epoch ${before} is odd after ${MAX_LOAD_RETRIES + 1} attempts — ` +
+          `returning possibly-torn snapshot from ${dir}`
+        );
+      }
+      scanAndSync();
+      const after = readEpoch(dir);
+      if (before === after) break;
+      if (attempt === MAX_LOAD_RETRIES) {
+        debug(
+          `Store epoch changed ${before} -> ${after} across load scan after ` +
+          `${MAX_LOAD_RETRIES + 1} attempts — returning possibly-torn snapshot from ${dir}`
+        );
+        break;
+      }
+      // otherwise: loop and retry with a fresh scan
+    }
 
     // Assemble the nested `entries` tree from the flat per-key cache.
     const flat: Record<string, CodexValue> = {};
@@ -315,6 +403,14 @@ export function createDirectoryStore(
     ensureDir();
 
     withFileLock(getStoreLockKey(dir), () => {
+      // 0. Begin commit: bump epoch to the next odd value. Readers that
+      //    observe an odd epoch loop in their seqlock retry until we finish.
+      //    readEpoch() returns 0 if the file is missing, so the first save
+      //    on a fresh store transitions 0 → 1 → 2.
+      const startEpoch = readEpoch(dir);
+      const inProgressEpoch = startEpoch + (startEpoch % 2 === 0 ? 1 : 2);
+      writeEpoch(dir, inProgressEpoch);
+
       // 1. Flatten new entries to leaves (authoritative new state).
       const newFlat = flattenObject(data.entries as Record<string, unknown>);
 
@@ -338,9 +434,8 @@ export function createDirectoryStore(
       }
 
       // 4. Apply deltas. Each atomicWriteFileSync is individually atomic;
-      //    within the directory lock, multi-file writes are serialized against
-      //    other writers (other readers may observe a partial state, but each
-      //    individual file read is atomic so they see consistent values).
+      //    concurrent readers detect mid-commit state via the odd epoch we
+      //    wrote in step 0 and retry their scan in load().
       for (const key of toDelete) {
         try {
           fs.unlinkSync(entryFilePath(dir, key));
@@ -380,6 +475,10 @@ export function createDirectoryStore(
         );
         confirmCache = { ...data.confirm };
       }
+
+      // 6. End commit: bump epoch to the next even value. Any reader that
+      //    snapshots the epoch from here on will see a stable, committed state.
+      writeEpoch(dir, inProgressEpoch + 1);
     });
   }
 
@@ -414,10 +513,32 @@ export interface DirectoryMigrationResult {
  * in the Phase 1 comment). Untracked entries (no `_meta` timestamp) migrate
  * with no `meta` block, preserving the `[untracked]` staleness label.
  *
- * No locking: migration runs on first store access in a given session, before
- * any concurrent writers would exist.
+ * Concurrency: wrapped in `withFileLock` using the same lock key as the
+ * steady-state store (`<newDirPath>.lock`). This serializes concurrent
+ * first-run migrations — the second process waits, then observes the new
+ * directory and returns `already-present`. It also guarantees that a
+ * migration never races a normal `save()` on the same store.
+ *
+ * If the parent directory of `newDirPath` doesn't exist yet (e.g., pristine
+ * install before `~/.codexcli/` has been created), lock acquisition will
+ * fail and `withFileLock` will fall through to running unlocked. This is
+ * still safe: there's nothing to race with on a truly-fresh install.
  */
 export function migrateFileToDirectory(
+  oldFilePath: string,
+  newDirPath: string
+): DirectoryMigrationResult {
+  return withFileLock(getStoreLockKey(newDirPath), () =>
+    migrateFileToDirectoryLocked(oldFilePath, newDirPath)
+  );
+}
+
+/**
+ * Core migration body. Invoked from {@link migrateFileToDirectory} while
+ * holding the store lock. Not exported — callers should always go through
+ * the locked entry point.
+ */
+function migrateFileToDirectoryLocked(
   oldFilePath: string,
   newDirPath: string
 ): DirectoryMigrationResult {
@@ -501,6 +622,11 @@ export function migrateFileToDirectory(
     // "aliases: {}" vs "aliases: never-existed").
     atomicWriteFileSync(path.join(tmpDirPath, ALIASES_FILE), serializeSidecar(aliases));
     atomicWriteFileSync(path.join(tmpDirPath, CONFIRM_FILE), serializeSidecar(confirm));
+
+    // Seed the epoch at 0 (stable/even). The first post-migration save()
+    // will bump it to 1 → 2, and readers running concurrently with that
+    // first save will correctly detect the in-progress commit.
+    writeEpoch(tmpDirPath, 0);
 
     // Atomic swap: rename the fully-written tmp directory to the final path.
     fs.renameSync(tmpDirPath, newDirPath);


### PR DESCRIPTION
Three targeted fixes addressing review feedback on the v1.10.0 store hardening PR.

## Changes

- **`readEpoch()` validation** — replaced `Number.isFinite` with `Number.isSafeInteger(x) && x >= 0`. Fractional (`1.5`), negative, or out-of-range values now fall back to `0` instead of breaking the even/odd seqlock invariant.

- **`ensureReadme()` atomicity** — replaced the `existsSync` + `atomicWriteFileSync` two-step with a single `writeFileSync(path, content, { flag: 'wx' })`. The `O_CREAT | O_EXCL` kernel semantics close the TOCTOU window: a concurrently created or user-customized `_README.md` is never clobbered. `EEXIST` is silenced; other errors still route to `debug()`.

  ```ts
  // before
  if (fs.existsSync(readmePath)) return;
  atomicWriteFileSync(readmePath, README_CONTENT);

  // after
  try {
    fs.writeFileSync(readmePath, README_CONTENT, { flag: 'wx' });
  } catch (err) {
    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return;
    debug(`Failed to write ${README_FILE} in ${dir}: ${String(err)}`);
  }
  ```

- **Test mtime determinism** — replaced the busy-wait spin loop in the sidecar cache test with `fs.utimesSync(path, mtime+1000, mtime+1000)`. The `+1000 ms` step is sufficient for filesystems with 1-second mtime granularity, eliminating CPU waste and flakiness.