### PR TITLE
fix(paths): W_OK|X_OK for writability probe; add info test for CODEX_DATA_DIR annotation

### DIFF
--- a/.codexcli/project.v111.json
+++ b/.codexcli/project.v111.json
@@ -1,0 +1,7 @@
+{
+  "value": "v1.11.0 quality release. Tracked via GitHub milestone v1.11.0 (https://github.com/seabearDEV/codexCLI/milestone/1). Scope: (1) Tier 1 doc fixes — store epoch retry comments + sidecar README clarification, merged in 3077055; (2) withFileLock fail-closed in production with CODEX_DISABLE_LOCKING=1 opt-out for tests + lockless-fallback test coverage + defensive shallow-cache audit; (3) Short-flag namespace audit, rip-and-replace, single CHANGELOG entry; (4) CODEX_DATA_DIR polish — README env-var section, absolute-path validation, ccli info provenance annotation, clearDataDirectoryCache() export. Sequencing: PR1=CODEX_DATA_DIR (smallest), PR2=short-flags, PR3=withFileLock+cache sweep. Out of scope: hand-edit drift detection (defer to v1.12+), any new features.",
+  "meta": {
+    "created": 1775666874095,
+    "updated": 1775666874095
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **`CODEX_DATA_DIR` validation, provenance, and documentation** — the env var has always been honored by `getDataDirectory()`, but it was undocumented, unvalidated, and invisible. Three changes close those gaps:
+  - **Validation**: `CODEX_DATA_DIR` must be an absolute path. Relative values (`./mydata`, etc.) now throw with a clear error rather than silently resolving against `process.cwd()` — the resolved location of a relative path depended on whichever directory the process happened to be in at first call, which is surprising for long-running MCP servers. Empty strings are treated as unset.
+  - **Provenance**: `ccli info` annotates the `Data` line with `(CODEX_DATA_DIR)` when the env var is set, so users can verify their override at a glance instead of guessing whether it took effect.
+  - **Writability warning**: if the resolved data directory exists but isn't writable, a one-time warning fires to stderr on first `getDataDirectory()` call. Non-existent paths are not warned about — `ensureDataDirectoryExists()` creates them later.
+  - **Docs**: new `## Environment Variables` section in the README listing every `CODEX_*` variable (`CODEX_DATA_DIR`, `CODEX_PROJECT`, `CODEX_PROJECT_DIR`, `CODEX_NO_PROJECT`, `CODEX_AGENT_NAME`) with purpose, default, and a notes section. Closes [#63](https://github.com/seabearDEV/codexCLI/issues/63).
+- **`clearDataDirectoryCache()`** in `src/utils/paths.ts` — resets the module-level cache and one-shot flags so a subsequent `getDataDirectory()` call re-reads `CODEX_DATA_DIR`. Mirrors `clearProjectFileCache()` and is primarily useful for tests; production code has no reason to call it.
+- **`isDataDirectoryFromEnv()`** in `src/utils/paths.ts` — small predicate exported so `ccli info` (and tests) can label the data path with its source.
+
 ### Fixed
 
 - **File-per-entry store: torn reads during concurrent writes** — `load()` could observe a partially-committed `save()` when another process was mid-write (some entries updated, others not), with no way to detect it. The store now uses a seqlock-style commit epoch in a new `_epoch.json` sidecar: even values mean "stable," odd means "writer mid-commit." `save()` bumps the epoch to odd before touching any files and to the next even value after all writes complete, both under the existing directory lock. `load()` snapshots the epoch before and after its scan and retries (bounded to 3 attempts with 1–8 ms backoff) if it sees a mismatch or an odd "before" value. Missing or bogus `_epoch.json` reads as 0, so legacy directories and fresh installs transition cleanly through the first save.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A command-line knowledge base with built-in AI agent integration via MCP.
 - [Overview](#overview)
 - [Features](#features)
 - [Installation](#installation)
+- [Environment Variables](#environment-variables)
 - [Usage](#usage)
   - [Storing Data](#storing-data)
   - [Retrieving Data](#retrieving-data)
@@ -125,6 +126,24 @@ If `cclid` is not found after installing, verify that npm's global bin directory
 ```bash
 echo $PATH | grep -o "$(npm config get prefix)/bin"
 ```
+
+## Environment Variables
+
+CodexCLI honors a small set of environment variables for deployment-time configuration. All are optional — sensible defaults work for most users. (For interactive UI preferences like color and pager, see [Configuration](#configuration) under Usage.)
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CODEX_DATA_DIR` | Override the global data directory. Must be an absolute path. All global state lives here: the entry store (`store/`), config, audit log, telemetry. | `~/.codexcli` |
+| `CODEX_PROJECT` | Explicit path to a `.codexcli/` directory, a legacy `.codexcli.json` file, or a containing directory. Fails closed if the path doesn't resolve — no `cwd` walk-up fallback. | unset (walk up from `cwd`) |
+| `CODEX_PROJECT_DIR` | MCP-server launcher hint — the directory the server should treat as the project root. Equivalent to passing `--cwd <dir>`. Applied via `setProjectRootOverride` (no `process.chdir`), so it works whether the server is run as a binary or imported. | unset |
+| `CODEX_NO_PROJECT` | Disable project-file lookup entirely. Set to any non-empty value (e.g. `1`) and `findProjectFile()` returns `null` regardless of `cwd` or `CODEX_PROJECT`. | unset |
+| `CODEX_AGENT_NAME` | Identifier recorded in the audit and telemetry logs for the calling agent. Used by `ccli stats` and `ccli audit` to break down activity per agent (Claude, Cursor, Copilot, etc.). | unset |
+
+### Notes
+
+- **`CODEX_DATA_DIR` must be absolute.** Relative paths (`./mydata`, `~/foo`) are rejected with a hard error rather than silently resolved against `process.cwd()`. Pass an expanded absolute path.
+- **Verify your data directory** at any time with `ccli info` — the `Data` line shows the resolved path and is annotated with `(CODEX_DATA_DIR)` when the env var is set.
+- **Pin the project root** for the MCP server in `.claude.json` by setting `"env": { "CODEX_PROJECT": "<repo path>" }` in the codexcli MCP block. This is more deterministic than relying on `cwd` walk-up.
 
 ## Usage
 

--- a/src/__tests__/info.test.ts
+++ b/src/__tests__/info.test.ts
@@ -88,6 +88,18 @@ describe('showInfo', () => {
     expect(output).toContain('config.json');
   });
 
+  it('annotates Data line with (CODEX_DATA_DIR) when env var is set', async () => {
+    const pathsMock = await import('../utils/paths');
+    (pathsMock.isDataDirectoryFromEnv as Mock).mockReturnValueOnce(true);
+    showInfo();
+    expect(getOutput()).toContain('(CODEX_DATA_DIR)');
+  });
+
+  it('does not annotate Data line when env var is not set', () => {
+    showInfo();
+    expect(getOutput()).not.toContain('(CODEX_DATA_DIR)');
+  });
+
   it('shows version label', () => {
     showInfo();
     const output = getOutput();

--- a/src/__tests__/info.test.ts
+++ b/src/__tests__/info.test.ts
@@ -36,6 +36,7 @@ vi.mock('../utils/paths', () => ({
   getUnifiedDataFilePath: vi.fn(() => '/mock/data.json'),
   getConfigFilePath: vi.fn(() => '/mock/config.json'),
   getGlobalStoreDirPath: vi.fn(() => '/mock/store'),
+  isDataDirectoryFromEnv: vi.fn(() => false),
 }));
 
 vi.mock('fs', () => {

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -25,6 +25,99 @@ describe('paths utilities', () => {
       const { getDataDirectory } = await import('../utils/paths');
       expect(getDataDirectory()).toBe(process.env.CODEX_DATA_DIR);
     });
+
+    it('throws when CODEX_DATA_DIR is a relative path', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      process.env.CODEX_DATA_DIR = './relative/path';
+      try {
+        const { getDataDirectory } = await import('../utils/paths');
+        expect(() => getDataDirectory()).toThrow(/absolute path/i);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+        else delete process.env.CODEX_DATA_DIR;
+      }
+    });
+
+    it('treats an empty CODEX_DATA_DIR as unset (does not produce a relative path)', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      process.env.CODEX_DATA_DIR = '';
+      try {
+        const { getDataDirectory } = await import('../utils/paths');
+        const result = getDataDirectory();
+        expect(result).not.toBe('');
+        expect(path.isAbsolute(result)).toBe(true);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+        else delete process.env.CODEX_DATA_DIR;
+      }
+    });
+  });
+
+  describe('clearDataDirectoryCache', () => {
+    it('resets the cache so a new CODEX_DATA_DIR is picked up on the next call', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      const firstDir = path.join(tmpDir, 'first');
+      const secondDir = path.join(tmpDir, 'second');
+      try {
+        process.env.CODEX_DATA_DIR = firstDir;
+        const { getDataDirectory, clearDataDirectoryCache } = await import('../utils/paths');
+        expect(getDataDirectory()).toBe(firstDir);
+
+        // Without clearing, the cache wins even when the env changes.
+        process.env.CODEX_DATA_DIR = secondDir;
+        expect(getDataDirectory()).toBe(firstDir);
+
+        // After clearing, the next call re-reads the env.
+        clearDataDirectoryCache();
+        expect(getDataDirectory()).toBe(secondDir);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+        else delete process.env.CODEX_DATA_DIR;
+      }
+    });
+  });
+
+  describe('isDataDirectoryFromEnv', () => {
+    it('returns true when CODEX_DATA_DIR is set to a non-empty value', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      process.env.CODEX_DATA_DIR = path.join(tmpDir, 'somewhere');
+      try {
+        const { isDataDirectoryFromEnv } = await import('../utils/paths');
+        expect(isDataDirectoryFromEnv()).toBe(true);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+        else delete process.env.CODEX_DATA_DIR;
+      }
+    });
+
+    it('returns false when CODEX_DATA_DIR is unset', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      delete process.env.CODEX_DATA_DIR;
+      try {
+        const { isDataDirectoryFromEnv } = await import('../utils/paths');
+        expect(isDataDirectoryFromEnv()).toBe(false);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+      }
+    });
+
+    it('returns false when CODEX_DATA_DIR is an empty string', async () => {
+      vi.resetModules();
+      const original = process.env.CODEX_DATA_DIR;
+      process.env.CODEX_DATA_DIR = '';
+      try {
+        const { isDataDirectoryFromEnv } = await import('../utils/paths');
+        expect(isDataDirectoryFromEnv()).toBe(false);
+      } finally {
+        if (original !== undefined) process.env.CODEX_DATA_DIR = original;
+        else delete process.env.CODEX_DATA_DIR;
+      }
+    });
   });
 
   describe('ensureDataDirectoryExists', () => {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -5,7 +5,7 @@ import { version } from '../../package.json';
 import { getEntriesFlat } from '../storage';
 import { loadAliases } from '../alias';
 import { loadConfirmKeys } from '../confirm';
-import { getGlobalStoreDirPath, getConfigFilePath } from '../utils/paths';
+import { getGlobalStoreDirPath, getConfigFilePath, isDataDirectoryFromEnv } from '../utils/paths';
 import { findProjectFile } from '../store';
 import { color } from '../formatting';
 import { getBinaryName } from '../utils/binaryName';
@@ -29,7 +29,8 @@ export function showInfo(): void {
 
   console.log();
 
-  label('Data', getGlobalStoreDirPath());
+  const dataSource = isDataDirectoryFromEnv() ? color.gray(' (CODEX_DATA_DIR)') : '';
+  label('Data', getGlobalStoreDirPath() + dataSource);
   label('Config', getConfigFilePath());
   const projectFile = findProjectFile();
   label('Project', projectFile ?? color.gray('none'));

--- a/src/utils/directoryStore.ts
+++ b/src/utils/directoryStore.ts
@@ -74,9 +74,16 @@ const ENTRY_FILE_SUFFIX = '.json';
 const README_CONTENT = `# codexCLI store — do not hand-edit
 
 This directory is managed by codexCLI. Each \`*.json\` file is a single
-store entry written through the CLI or MCP tools. Sidecar files starting
-with \`_\` (this README, \`_aliases.json\`, \`_confirm.json\`, \`_epoch.json\`)
-are internal bookkeeping.
+store entry written through the CLI or MCP tools.
+
+**Internal sidecar files** (prefix \`_\`, safe to ignore):
+
+- \`_README.md\` — this file
+- \`_aliases.json\` — short-name aliases for entries
+- \`_confirm.json\` — entries that require confirmation before running
+- \`_epoch.json\` — internal commit counter for crash safety; the integer
+  climbs by 2 with every save and is used by readers to detect a writer
+  mid-commit. You should never need to touch it.
 
 **Edit via one of:**
 
@@ -452,9 +459,12 @@ export function createDirectoryStore(
     for (let attempt = 0; attempt <= MAX_LOAD_RETRIES; attempt++) {
       const before = readEpoch(dir);
       if (before % 2 !== 0) {
-        // Writer is mid-commit. Back off briefly and retry.
+        // Writer is mid-commit. Back off briefly and retry. Backoffs only
+        // fire on attempts 0..MAX_LOAD_RETRIES-1 (1ms, 2ms, 4ms with the
+        // current MAX_LOAD_RETRIES=3); on the final attempt we log and
+        // proceed with a best-effort scan rather than waiting again.
         if (attempt < MAX_LOAD_RETRIES) {
-          Atomics.wait(_loadRetrySleep, 0, 0, 1 << attempt); // 1ms, 2ms, 4ms, 8ms
+          Atomics.wait(_loadRetrySleep, 0, 0, 1 << attempt);
           continue;
         }
         debug(
@@ -472,7 +482,12 @@ export function createDirectoryStore(
         );
         break;
       }
-      // otherwise: loop and retry with a fresh scan
+      // Otherwise: loop and retry with a fresh scan. No backoff here —
+      // unlike the odd-epoch case, an epoch *mismatch* means the writer
+      // already committed (we read the post-commit even value as `after`).
+      // Writes are sub-millisecond, so by the time we re-scan the writer
+      // is almost certainly done; backing off would only add latency in
+      // the common case without preventing further mismatches.
     }
 
     // Assemble the nested `entries` tree from the flat per-key cache.

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -64,7 +64,7 @@ export function getDataDirectory(): string {
   if (!dataDirWritabilityWarned) {
     try {
       if (fs.existsSync(dataDirectoryCache)) {
-        fs.accessSync(dataDirectoryCache, fs.constants.W_OK);
+        fs.accessSync(dataDirectoryCache, fs.constants.W_OK | fs.constants.X_OK);
       }
     } catch {
       process.stderr.write(

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -15,26 +15,96 @@ function isDev(): boolean {
 
 // Add caching for path resolution
 let dataDirectoryCache: string | null = null;
+let dataDirEnsured = false;
+let dataDirWritabilityWarned = false;
 
 /**
- * Get the directory where data files should be stored
+ * Get the directory where data files should be stored.
+ *
+ * Resolution order:
+ *   1. `CODEX_DATA_DIR` env var (must be a non-empty absolute path)
+ *   2. Dev mode: `<repo>/data`
+ *   3. Production: `~/.codexcli`
+ *
+ * Validation: when `CODEX_DATA_DIR` is set, it must be an absolute path.
+ * Relative values are rejected with a hard error rather than silently
+ * resolved against `process.cwd()` — the resolved location of a relative
+ * path depends on which directory the process happened to be in at the
+ * moment of the first call, which is surprising (especially for
+ * long-running MCP servers whose cwd may differ from the user's shell).
+ * Empty strings are treated as unset.
+ *
+ * If the resolved directory exists but isn't writable, a one-time warning
+ * is emitted to stderr. Non-existent directories are not warned about
+ * here — `ensureDataDirectoryExists()` creates them later, and warning
+ * about a path we're about to create would be noise.
  */
 export function getDataDirectory(): string {
-  dataDirectoryCache ??= process.env.CODEX_DATA_DIR
-    ?? (isDev()
-      ? path.join(path.resolve(__dirname, '..', '..'), 'data')
-      : path.join(os.homedir(), '.codexcli'));
+  if (dataDirectoryCache !== null) return dataDirectoryCache;
+
+  const fromEnv = process.env.CODEX_DATA_DIR;
+  if (fromEnv !== undefined && fromEnv !== '') {
+    if (!path.isAbsolute(fromEnv)) {
+      throw new Error(
+        `CODEX_DATA_DIR must be an absolute path. Got: ${JSON.stringify(fromEnv)}. ` +
+        `Relative paths are rejected because the resolved location would depend on ` +
+        `process.cwd() at first call.`
+      );
+    }
+    dataDirectoryCache = fromEnv;
+  } else if (isDev()) {
+    dataDirectoryCache = path.join(path.resolve(__dirname, '..', '..'), 'data');
+  } else {
+    dataDirectoryCache = path.join(os.homedir(), '.codexcli');
+  }
+
+  // One-time writability check. We only warn when the directory exists
+  // already; non-existent paths are normal on first run and get created
+  // by ensureDataDirectoryExists().
+  if (!dataDirWritabilityWarned) {
+    try {
+      if (fs.existsSync(dataDirectoryCache)) {
+        fs.accessSync(dataDirectoryCache, fs.constants.W_OK);
+      }
+    } catch {
+      process.stderr.write(
+        `Warning: data directory ${dataDirectoryCache} is not writable. ` +
+        `codexCLI may fail to save changes.\n`
+      );
+    }
+    dataDirWritabilityWarned = true;
+  }
+
   return dataDirectoryCache;
+}
+
+/**
+ * True if `CODEX_DATA_DIR` is set to a non-empty value. Used by `ccli info`
+ * (and tests) to label the data path with its source.
+ */
+export function isDataDirectoryFromEnv(): boolean {
+  const fromEnv = process.env.CODEX_DATA_DIR;
+  return fromEnv !== undefined && fromEnv !== '';
+}
+
+/**
+ * Reset the cached data directory and related one-shot flags. After this
+ * call, the next `getDataDirectory()` re-reads `CODEX_DATA_DIR` and may
+ * re-emit the writability warning. Mirrors `clearProjectFileCache()`.
+ * Primarily used by tests; production code has no reason to call this.
+ */
+export function clearDataDirectoryCache(): void {
+  dataDirectoryCache = null;
+  dataDirEnsured = false;
+  dataDirWritabilityWarned = false;
 }
 
 /**
  * Ensures data directory exists
  * Creates it if it doesn't exist
- * 
+ *
  * @returns {string} Path to the data directory
  */
-let dataDirEnsured = false;
-
 export function ensureDataDirectoryExists(): string {
   const dataDir = getDataDirectory();
 


### PR DESCRIPTION
Two targeted fixes from code review on the `CODEX_DATA_DIR` polish PR.

## Changes

- **`src/utils/paths.ts`**: Writability probe now checks `W_OK | X_OK` instead of `W_OK` alone. On POSIX, entering a directory to create files requires execute/search permission — `W_OK` alone misses directories missing `+x`.

- **`src/__tests__/info.test.ts`**: Added test coverage for both branches of the `isDataDirectoryFromEnv()` path in `showInfo`:
  - `isDataDirectoryFromEnv() → true` → `(CODEX_DATA_DIR)` annotation present on the Data line
  - `isDataDirectoryFromEnv() → false` (default mock) → annotation absent