### PR TITLE
fix: MCP audit/telemetry log absolute project path (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
   Telemetry/audit gains `refusedReason: 'project_unresolved'` on refused calls and `rescuedByExplicitGlobal: true` on calls that succeeded under explicit `scope: 'global'` despite project resolution failing — lets us measure how often the escape hatch is in use post-deploy.
 
+### Fixed
+
+- **MCP audit/telemetry rows now log absolute project paths** (`#102`): when the MCP server received a relative launcher hint (`CODEX_PROJECT_DIR=.` env or `--cwd .` arg), `setProjectRootOverride` stored the relative value verbatim, the walk-up resolver returned `.codexcli` (relative), and downstream `path.dirname()` collapsed to `"."` in 234 of 302 audit rows on the 2026-05-05 soak machine. The override now absolutizes via `path.resolve()` at set time, so all walk-up branches return absolute paths and audit/telemetry `project` fields match the resolver's absolute output. Forward-only — historical `"."` rows are not backfilled.
+
 ## [1.13.0] - 2026-04-23
 
 Agent-first release driven by mining a 584-call, 15-day real-usage dataset (see `docs/dogfooding-real-usage.md`). Eleven issues closed across three themes: make agent tool-selection unambiguous (#92), make the audit signal clean enough to mine again (#93 + #94), and formalize the cross-session handoff pattern agents organically converged on (#91). The rest — small bug fixes, soak findings, and the first two Layer 2 tools from the seedRoadmap — fell into the same cycle once the milestone was trimmed to match.

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -401,5 +401,33 @@ describe('paths utilities', () => {
         setProjectRootOverride(null);
       }
     });
+
+    // Issue #102: a relative override (e.g. CODEX_PROJECT_DIR=. / --cwd .)
+    // used to yield a relative resolved path, which downstream path.dirname()
+    // collapsed to "." in audit rows.
+    it('setProjectRootOverride absolutizes relative input so resolver returns an absolute path', async () => {
+      fs.mkdirSync(path.join(tmpDir, '.codexcli'));
+
+      const originalCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      vi.resetModules();
+      const { findProjectFile, getProjectRootOverride, clearProjectFileCache, setProjectRootOverride } = await import('../utils/paths');
+      clearProjectFileCache();
+      try {
+        setProjectRootOverride('.');
+        expect(path.isAbsolute(getProjectRootOverride() as string)).toBe(true);
+        const resolved = findProjectFile();
+        expect(resolved).not.toBeNull();
+        expect(path.isAbsolute(resolved as string)).toBe(true);
+        // The audit-row contract: path.dirname() of the resolved value is
+        // the project directory in absolute form, never bare "." (#102).
+        expect(path.dirname(resolved as string)).not.toBe('.');
+        expect(path.isAbsolute(path.dirname(resolved as string))).toBe(true);
+      } finally {
+        setProjectRootOverride(null);
+        process.chdir(originalCwd);
+      }
+    });
   });
 });

--- a/src/__tests__/paths.test.ts
+++ b/src/__tests__/paths.test.ts
@@ -274,6 +274,34 @@ describe('paths utilities', () => {
         delete process.env.CODEX_NO_PROJECT;
       }
     });
+
+    // Issue #102: a relative override (e.g. CODEX_PROJECT_DIR=. / --cwd .)
+    // used to yield a relative resolved path, which downstream path.dirname()
+    // collapsed to "." in audit rows.
+    it('setProjectRootOverride absolutizes relative input so resolver returns an absolute path', async () => {
+      fs.mkdirSync(path.join(tmpDir, '.codexcli'));
+
+      const originalCwd = process.cwd();
+      process.chdir(tmpDir);
+
+      vi.resetModules();
+      const { findProjectFile, getProjectRootOverride, clearProjectFileCache, setProjectRootOverride } = await import('../utils/paths');
+      clearProjectFileCache();
+      try {
+        setProjectRootOverride('.');
+        expect(path.isAbsolute(getProjectRootOverride() as string)).toBe(true);
+        const resolved = findProjectFile();
+        expect(resolved).not.toBeNull();
+        expect(path.isAbsolute(resolved as string)).toBe(true);
+        // The audit-row contract: path.dirname() of the resolved value is
+        // the project directory in absolute form, never bare "." (#102).
+        expect(path.dirname(resolved as string)).not.toBe('.');
+        expect(path.isAbsolute(path.dirname(resolved as string))).toBe(true);
+      } finally {
+        setProjectRootOverride(null);
+        process.chdir(originalCwd);
+      }
+    });
   });
 
   describe('file path getters', () => {
@@ -399,34 +427,6 @@ describe('paths utilities', () => {
         expect(findProjectStoreDir()).toBeNull();
       } finally {
         setProjectRootOverride(null);
-      }
-    });
-
-    // Issue #102: a relative override (e.g. CODEX_PROJECT_DIR=. / --cwd .)
-    // used to yield a relative resolved path, which downstream path.dirname()
-    // collapsed to "." in audit rows.
-    it('setProjectRootOverride absolutizes relative input so resolver returns an absolute path', async () => {
-      fs.mkdirSync(path.join(tmpDir, '.codexcli'));
-
-      const originalCwd = process.cwd();
-      process.chdir(tmpDir);
-
-      vi.resetModules();
-      const { findProjectFile, getProjectRootOverride, clearProjectFileCache, setProjectRootOverride } = await import('../utils/paths');
-      clearProjectFileCache();
-      try {
-        setProjectRootOverride('.');
-        expect(path.isAbsolute(getProjectRootOverride() as string)).toBe(true);
-        const resolved = findProjectFile();
-        expect(resolved).not.toBeNull();
-        expect(path.isAbsolute(resolved as string)).toBe(true);
-        // The audit-row contract: path.dirname() of the resolved value is
-        // the project directory in absolute form, never bare "." (#102).
-        expect(path.dirname(resolved as string)).not.toBe('.');
-        expect(path.isAbsolute(path.dirname(resolved as string))).toBe(true);
-      } finally {
-        setProjectRootOverride(null);
-        process.chdir(originalCwd);
       }
     });
   });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -162,9 +162,15 @@ let projectRootOverride: string | null = null;
 /**
  * Set the directory used as the starting point for project file discovery,
  * overriding process.cwd(). Pass null to clear. Clears the cached result.
+ *
+ * Relative input is absolutized via `path.resolve()` so the walk-up always
+ * starts from an absolute directory. Without this, an `MCP_PROJECT_DIR=.` /
+ * `--cwd .` launcher hint would yield a relative `.codexcli` from the
+ * resolver, which downstream `path.dirname()` reduced to `"."` in audit
+ * rows (issue #102).
  */
 export function setProjectRootOverride(dir: string | null): void {
-  projectRootOverride = dir;
+  projectRootOverride = dir === null ? null : path.resolve(dir);
   projectFileCache = null;
   projectStoreDirCache = null;
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -164,7 +164,7 @@ let projectRootOverride: string | null = null;
  * overriding process.cwd(). Pass null to clear. Clears the cached result.
  *
  * Relative input is absolutized via `path.resolve()` so the walk-up always
- * starts from an absolute directory. Without this, an `MCP_PROJECT_DIR=.` /
+ * starts from an absolute directory. Without this, a `CODEX_PROJECT_DIR=.` /
  * `--cwd .` launcher hint would yield a relative `.codexcli` from the
  * resolver, which downstream `path.dirname()` reduced to `"."` in audit
  * rows (issue #102).


### PR DESCRIPTION
## Summary

- Closes #102 — MCP audit/telemetry rows logged `project: "."` instead of the resolved absolute path on 234 of 302 rows in the 2026-05-05 soak data.
- Root cause: `setProjectRootOverride` stored relative launcher hints (`CODEX_PROJECT_DIR=.` / `--cwd .`) verbatim. The walk-up resolver then produced a relative `.codexcli` and `path.dirname()` collapsed to `"."`.
- Fix: absolutize via `path.resolve()` at set time. All resolver branches now return absolute paths.

## Why this only affected MCP

The CLI never calls `setProjectRootOverride` and walks from `process.cwd()`, which is always absolute. The override is MCP-specific (listRoots / `CODEX_PROJECT_DIR` / `--cwd`), so only MCP rows hit the bug.

## Out of scope

- Backfilling historical `"."` rows (per issue acceptance — forward-only).
- Changing `codex_stats` / `codex_audit` to handle `.` (becomes unnecessary after the fix).

## Test plan

- [x] Unit test added: relative override → resolver returns absolute path, `path.dirname()` is not `"."`.
- [x] `npm run build && npm run lint && npm test` — 1351 pass (was 1350).
- [ ] Manual: after merge, verify a fresh MCP audit row from a `CODEX_PROJECT_DIR=.` launcher logs an absolute path.